### PR TITLE
Save layout only suggested when layout changes

### DIFF
--- a/templates/project/assets/javascripts/application.coffee
+++ b/templates/project/assets/javascripts/application.coffee
@@ -22,3 +22,4 @@ Dashing.on 'ready', ->
       avoid_overlapped_widgets: !Dashing.customGridsterLayout
       draggable:
         stop: Dashing.showGridsterInstructions
+        start: -> Dashing.currentWidgetPositions = Dashing.getWidgetPositions()

--- a/templates/project/assets/javascripts/dashing.gridster.coffee
+++ b/templates/project/assets/javascripts/dashing.gridster.coffee
@@ -13,17 +13,22 @@ Dashing.gridsterLayout = (positions) ->
     $(widget).attr('data-row', positions[index].row)
     $(widget).attr('data-col', positions[index].col)
 
+Dashing.getWidgetPositions = ->
+  $(".gridster ul:first").gridster().data('gridster').serialize()
+
 Dashing.showGridsterInstructions = ->
-    data = $(".gridster ul:first").gridster().data('gridster').serialize()
+  newWidgetPositions = Dashing.getWidgetPositions()
+
+  unless JSON.stringify(newWidgetPositions) == JSON.stringify(Dashing.currentWidgetPositions)
+    Dashing.currentWidgetPositions = newWidgetPositions
     $('#save-gridster').slideDown()
     $('#gridster-code').text("
       <script type='text/javascript'>\n
       $(function() {\n
-      \ \ Dashing.gridsterLayout('#{JSON.stringify(data)}')\n
+      \ \ Dashing.gridsterLayout('#{JSON.stringify(Dashing.currentWidgetPositions)}')\n
       });\n
       </script>
     ")
-
 
 $ ->
   $('#save-gridster').leanModal()


### PR DESCRIPTION
Small change made to the client code to detect if the layout changes, and only display the "save layout" dialog when the layout has been changed from the current one. Currently, even if a small drag is made to any tile, the save layout dialog will dropdown. I see this change as making it a little less intrusive.
