### PR TITLE
Display 'last updated' using user's locale

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -44,7 +44,7 @@ class Dashing.Widget extends Batman.View
 
   @accessor 'updatedAtMessage', ->
     if updatedAt = @get('updatedAt')
-      timestamp = new Date(updatedAt)
+      timestamp = new Date(updatedAt * 1000)
       hours = timestamp.getHours()
       minutes = ("0" + timestamp.getMinutes()).slice(-2)
       "Last updated at #{hours}:#{minutes}"

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -81,7 +81,7 @@ end
 
 def send_event(id, body)
   body["id"] = id
-  body["updatedAt"] = Time.now
+  body["updatedAt"] = Time.now.to_i
   event = format_event(body.to_json)
   settings.history[id] = event
   settings.connections.each { |out| out << event }


### PR DESCRIPTION
I originally tried to do this by parsing the date string sent by stringifying Time.now, which worked happily in Chrome, but Safari wasn't fond it. I've changed both sides of the interface to use ticks instead, which, as far as I know should work happily in all browsers. 
