### PR TITLE
Custom task lookup

### DIFF
--- a/bin/dashing
+++ b/bin/dashing
@@ -50,7 +50,7 @@ module Dashing
       directory :project, @name
     end
 
-    desc "generate (widget/dashboard/job) NAME", "Creates a new widget, dashboard, or job."
+    desc "generate(:TEMPLATE) (widget/dashboard/job) NAME", "Creates a new widget, dashboard, or job."
     def generate(type, name)
       send("generate_#{type}".to_sym, name)
     rescue NoMethodError => e


### PR DESCRIPTION
Here's my crack at custom task functionality for Dashing.

It's a hybrid of how Thor does script lookup and how Rails does generator lookup.

[Thor::Runner](https://github.com/wycats/thor/blob/master/lib/thor/runner.rb) uses `method_missing` to find tasks that it doesn't recognise. I do the same here with the exception that I'm not looking for `.thor` files, I try to require a file with a namespace based on the task name. [Rails does something very similar when looking up generators](https://github.com/rails/rails/blob/master/railties/lib/rails/generators.rb#L274).

So what can you do with this?

This functionality allows people to write new widget, job, and dashboard templates for Dashing, package them up in gems, and maintain them without touching the Dashing codebase itself.

Users will install the gem, then invoke the new tasks through dashing itself.

Here's an example:

I've written a gem called [`dashing-weather`](https://github.com/davefp/dashing-weather) that provides job and widget templates for getting and displaying your local weather.
1. `gem install dashing-weather`
2. `dashing weather:install job NAME WOE_ID FORMAT`

That's it! Provided you're in a Dashing project when you call this you'll end up with a new job in the jobs folder that will fetch weather for you every 15 minutes.

The weather gem is still very rough, but it works to demonstrate the new functionality.

Gems that provide new tasks MUST be nested under the Dashing namespace, and extend Thor in the same way that Dashing itself does. Look at the [`weather.rb`](https://github.com/davefp/dashing-weather/blob/master/lib/dashing/weather.rb) example to get an idea of what this looks like.
