### PR TITLE
Halt 404 when no dashboard found 

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -49,7 +49,11 @@ end
 
 get '/:dashboard' do
   protected!
-  erb params[:dashboard].to_sym
+  begin
+    erb params[:dashboard].to_sym
+  rescue Errno::ENOENT
+    halt 404, "no such dashboard"
+  end
 end
 
 get '/views/:widget?.html' do


### PR DESCRIPTION
Prevents nasty message from sinatra when a dashboard does not exists, just `halt 404`
