### PR TITLE
Adds a simple double text widget

### DIFF
--- a/templates/project/widgets/doubletext/doubletext.coffee
+++ b/templates/project/widgets/doubletext/doubletext.coffee
@@ -1,0 +1,4 @@
+class Dashing.Doubletext extends Dashing.Widget
+  ready: ->
+
+  onData: (data) ->

--- a/templates/project/widgets/doubletext/doubletext.html
+++ b/templates/project/widgets/doubletext/doubletext.html
@@ -1,0 +1,7 @@
+<h1 class="titleone" data-bind="titleone"></h1>
+
+<h3 data-bind="textone"></h3>
+
+<h1 class="titletwo" data-bind="titletwo"></h1>
+
+<h3 data-bind="texttwo"></h3>

--- a/templates/project/widgets/doubletext/doubletext.scss
+++ b/templates/project/widgets/doubletext/doubletext.scss
@@ -1,0 +1,44 @@
+// ----------------------------------------------------------------------------
+// Sass declarations
+// ----------------------------------------------------------------------------
+$background-color:  #47bbb3;
+
+$title-color:       rgba(255, 255, 255, 0.7);
+$moreinfo-color:    rgba(255, 255, 255, 0.7);
+
+// ----------------------------------------------------------------------------
+// Widget-text styles
+// ----------------------------------------------------------------------------
+.widget-doubletext {
+
+  background-color: $background-color;
+
+  .title {
+    color: $title-color;
+  }
+
+  .more-info {
+    color: $moreinfo-color;
+  }
+
+  .updated-at {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  h3 {
+    font-size: 60px;
+  }
+
+
+  &.large h3 {
+    font-size: 70px;
+  }
+
+}
+.status-success {
+  background-color: green;
+}
+
+.status-fail {
+  background-color: $background-color;
+}


### PR DESCRIPTION
We use this simple widget to display the names of projects running on two different servers. We've found various uses for it and thought it might be good to include it in the official repo.
