### PR TITLE
Changes "dashize" for "snakeCase" to make the generated SCSS file match the class in the widget.

### DIFF
--- a/bin/dashing
+++ b/bin/dashing
@@ -20,26 +20,6 @@ end
 
 SCHEDULER = MockScheduler.new
 
-# TODO: Please. No. Monkey. Patching.
-class Thor
-  module Util
-    # Receives a string and convert it to a dash separated string. DashSeparated returns
-    # dash-separated.
-    #
-    # ==== Parameters
-    # String
-    #
-    # ==== Returns
-    # String
-    #
-    def self.dash_separated(str)
-      return str.downcase if str =~ /^[A-Z-]+$/
-      str.gsub(/\B[A-Z]/, '-\&').squeeze('-') =~ /-*(.*)/
-      return $+.downcase
-    end
-  end
-end
-
 module Dashing
 
   class CLI < Thor
@@ -47,6 +27,12 @@ module Dashing
 
     class << self
       attr_accessor :auth_token
+
+      def dash_separated(str)
+        return str.downcase if str =~ /^[A-Z-]+$/
+        str.gsub(/\B[A-Z]/, '-\&').squeeze('-') =~ /-*(.*)/
+        return $+.downcase
+      end
     end
 
     attr_accessor :name
@@ -54,7 +40,7 @@ module Dashing
     no_tasks do
       ['widget', 'dashboard', 'job'].each do |type|
         define_method "generate_#{type}" do |name|
-          @name = Thor::Util.dash_separated(name)
+          @name = CLI.dash_separated(name)
           directory type.to_sym, File.join("#{type}s")
         end
       end
@@ -66,7 +52,7 @@ module Dashing
 
     desc "new PROJECT_NAME", "Sets up ALL THE THINGS needed for your dashboard project."
     def new(name)
-      @name = Thor::Util.snake_case(name)
+      @name = CLI.dash_separated(name)
       directory :project, @name
     end
 


### PR DESCRIPTION
We're using the framework at our office and it looks great. 

![dashboard](https://f.cloud.github.com/assets/486325/136483/c582daf4-714c-11e2-9de5-9e170cf3868f.jpg)

It just bothered me that when I created widgets with more than one word in the name, the first generated SASS file and the widget's class didn't match.

You can see it if you run:

```
$ dashing g widget PowerRanger
```

Then go to ./widgets/power_ranger/power_ranger.scss and see:

```
.widget-power_ranger {
}
```

Happened to me that I started adding CSS but nothing changed. Some time after I figured that the class that was generated into the SASS file was not right, better, the class given to the widget's element wasn't the same.

```
<div class="widget widget-power-ranger"></div>
```

This fixes that by changing "power-ranger" to "power_ranger" in the class of the widget.

That's all.
