### PR TITLE
Font size of clock is too large, breaks layout

### DIFF
--- a/templates/project/assets/stylesheets/application.scss
+++ b/templates/project/assets/stylesheets/application.scss
@@ -99,7 +99,7 @@ h1 {
 }
 h2 {
   text-transform: uppercase;
-  font-size: 76px;
+  font-size: 65px;
   font-weight: 700;
   color: $text-color;
 }


### PR DESCRIPTION
Example of broken layout
![Example of broken layout](http://dl.dropbox.com/u/2608420/Screenshots/-rri_wt4662v.png)
