### PR TITLE
Send an X-Accel-Buffering in /events to disable nginx buffering

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -32,6 +32,7 @@ end
 
 get '/events', provides: 'text/event-stream' do
   protected!
+  response.headers['X-Accel-Buffering'] = 'no' # Disable buffering if behind an nginx
   stream :keep_open do |out|
     settings.connections << out
     out << latest_events


### PR DESCRIPTION
Without that widgets take a lot of time to load if you're deployed behind nginx.

See: http://wiki.nginx.org/X-accel#X-Accel-Buffering

Maybe it can be pushed in Sinatra itself inside the stream method.
