### PR TITLE
Dashboard from config

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -58,8 +58,8 @@ end
 get '/' do
   protected!
   begin
-  redirect "/" + (settings.default_dashboard || first_dashboard).to_s
-  rescue NoMethodError => e
+    redirect "/" + (settings.default_dashboard || first_dashboard).to_s
+  rescue NoMethodError
     raise Exception.new("There are no dashboards in your dashboard directory.")
   end
 end

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -157,7 +157,7 @@ end
 
 def first_dashboard
   files = Dir[File.join(settings.views, '*')].collect { |f| File.basename(f, '.*') }
-  files -= ['layout']
+  files -= ['layout', 'dynamic']
   files.sort.first
 end
 

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -1,5 +1,7 @@
 module Dashing
   class Job
+    include Sinatra::Delegator
+
     def initialize(event, config)
       @event = event
       @config = config

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -1,0 +1,41 @@
+module Dashing
+  class Job
+    def initialize(event, config)
+      @event = event
+      @config = config
+    end
+
+    def execute
+      data = do_execute
+      send_event(event, data) if data
+    end
+
+    protected
+    attr_reader :config
+
+    def do_execute
+      raise NotImplementedError.new("You must implement #{self.class}#do_execute!")
+    end
+
+    private
+    attr_reader :event
+  end
+
+  def self.load_dynamic_jobs(jobs)
+    Array(jobs).each do |job_def|
+      klass = const_get job_def[:class]
+
+      job = klass.new(job_def[:event], job_def[:data])
+
+      scheduler.every job_def[:every], :first_in => 0 do
+        job.execute
+      end
+    end
+  end
+
+  private
+
+  def self.scheduler
+    SCHEDULER
+  end
+end

--- a/templates/project/config/config.json
+++ b/templates/project/config/config.json
@@ -1,0 +1,88 @@
+{
+  "dashboards": {
+
+    "sample-dyn": {
+      "title": "Sample Dashboard",
+
+      "widgets": [
+        {
+          "title": "Hello",
+          "view": "Text",
+          "event": "welcome",
+          "sizex": 2,
+          "data": {
+            "text" : "This is your shiny new dashboard",
+            "moreinfo": "Protip: You can drag the widgets around!"
+          }
+        },
+        {
+          "title" : "Synergy",
+          "view"  : "Meter",
+          "event" : "synergy",
+          "data": {
+            "min": 0,
+            "max": 100
+          }
+        },
+        {
+          "title": "Buzzwords",
+          "view": "List",
+          "event": "buzzwords",
+          "sizey": 2,
+          "data": {
+            "unordered": true,
+            "moreinfo": "# of times said around the office"
+          }
+        },
+        {
+          "title" : "Current Valuation",
+          "view"  : "Number",
+          "event" : "valuation",
+          "data": {
+            "moreinfo": "in billions",
+            "prefix": "$"
+          }
+        },
+        {
+          "title" : "Convergence",
+          "view"  : "Graph",
+          "event" : "convergence",
+          "sizex" : 2,
+          "attributes": {
+            "style": "background-color:#ff9618"
+          }
+        },
+        {
+          "view": "Comments",
+          "event": "twitter-beer",
+          "sizex": 2,
+          "background_icon": "twitter"
+        },
+        {
+          "view"  : "Clock",
+          "background_icon" : "time",
+          "attributes": {
+            "style": "background-color: #FF77A8"
+          }
+        },
+        {
+          "view"  : "Image",
+          "data"  : {
+            "image": "/logo.png"
+          }
+        }
+      ]
+    }
+  },
+
+  "jobs": [
+    {
+      "event" : "twitter-beer",
+      "class" : "TwitterSearch",
+      "every" : "10m",
+      "data"  : {
+        "search_term": "beer -root"
+      }
+    }
+  ]
+}

--- a/templates/project/dashboards/dynamic.erb
+++ b/templates/project/dashboards/dynamic.erb
@@ -1,0 +1,29 @@
+<% dashboard ||= {} %>
+<% content_for(:title) { dashboard[:title] || "Dynamic dashboard" } %>
+<script type='text/javascript'>
+$(function() {
+    var widgetWidth = <%= dashboard[:widget_width] || 350 %>,
+        widgetHeight = <%= dashboard[:widget_height] || 350 %>;
+
+    Dashing.widget_base_dimensions = [widgetWidth, widgetHeight];
+    Dashing.numColumns = <%= dashboard[:num_columns] || 4 %>;
+});
+</script>
+<div class="gridster">
+  <ul>
+    <% widgets = dashboard[:widgets] || [] %>
+    <% widgets.each do |widget| %>
+      <% attrs = widget[:attributes] || {}
+         attrs['data-id'] = widget[:event] if widget[:event]
+         attrs['data-view'] = widget[:view]  
+         attrs['data-title'] = widget[:title]  
+         (widget[:data] || {}).each {|k,v| attrs["data-#{k}"] = v } %>
+      <li data-row="<%= widget[:row] || 1 %>" data-col="<%= widget[:col] || 1 %>" data-sizex="<%= widget[:sizex] || 1 %>" data-sizey="<%= widget[:sizey] || 1 %>">
+        <div <%= attrs.map{|attr, value| "#{attr}='#{value}'"}.join(" ") %>></div>
+        <% if icon = widget[:background_icon] %>
+          <i class="icon-<%= icon %> icon-background"></i>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/templates/project/dashboards/dynamic.erb
+++ b/templates/project/dashboards/dynamic.erb
@@ -15,9 +15,9 @@ $(function() {
     <% widgets.each do |widget| %>
       <% attrs = widget[:attributes] || {}
          attrs['data-id'] = widget[:event] if widget[:event]
-         attrs['data-view'] = widget[:view]  
-         attrs['data-title'] = widget[:title]  
-         (widget[:data] || {}).each {|k,v| attrs["data-#{k}"] = v } %>
+         attrs['data-view'] = widget[:view]
+         attrs['data-title'] = widget[:title]
+         (widget[:data] || {}).each {|k,v| attrs["data-#{k}"] = v.to_json } %>
       <li data-row="<%= widget[:row] || 1 %>" data-col="<%= widget[:col] || 1 %>" data-sizex="<%= widget[:sizex] || 1 %>" data-sizey="<%= widget[:sizey] || 1 %>">
         <div <%= attrs.map{|attr, value| "#{attr}='#{value}'"}.join(" ") %>></div>
         <% if icon = widget[:background_icon] %>
@@ -27,3 +27,4 @@ $(function() {
     <% end %>
   </ul>
 </div>
+

--- a/templates/project/jobs/twitter.rb
+++ b/templates/project/jobs/twitter.rb
@@ -10,19 +10,28 @@ Twitter.configure do |config|
   config.oauth_token_secret = 'YOUR_OAUTH_SECRET'
 end
 
-search_term = URI::encode('#todayilearned')
+class TwitterSearch < Dashing::Job
 
-SCHEDULER.every '10m', :first_in => 0 do |job|
-  begin
+  protected
+
+  def do_execute
+    search_term = URI::encode(config[:search_term])
+
     tweets = Twitter.search("#{search_term}").results
 
     if tweets
       tweets.map! do |tweet|
         { name: tweet.user.name, body: tweet.text, avatar: tweet.user.profile_image_url_https }
       end
-      send_event('twitter_mentions', comments: tweets)
+      return { comments: tweets }
     end
   rescue Twitter::Error
     puts "\e[33mFor the twitter widget to work, you need to put in your twitter API keys in the jobs/twitter.rb file.\e[0m"
   end
+end
+
+search_term = URI::encode('#todayilearned')
+job = TwitterSearch.new('twitter_mentions', {search_term: search_term})
+SCHEDULER.every '10m', :first_in => 0 do
+  job.execute
 end


### PR DESCRIPTION
Hello.

These changes allow you to define your dashboards and jobs in one file (config/config.json). 

In the future I want to be able to configure dashboards from the browser instead of hacking the code. This is the first step in this direction. 

Separation of job implementation from it's configuration allows better code reuse - see example of twitter job in config.json. 

To see it working check [http://localhost:3030/sample-dyn](http://localhost:3030/sample-dyn)
