### PR TITLE
Added an option to have a dashboard at the root url

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -42,8 +42,8 @@ end
 
 get '/' do
   begin
-    if defined? settings.home_dashboard
-      load_dashboard(settings.home_dashboard)
+    if defined? settings.root_dashboard
+      load_dashboard(settings.root_dashboard)
     else
       redirect "/" + (settings.default_dashboard || first_dashboard).to_s
     end


### PR DESCRIPTION
We encountered a few problems with the default behaviour of redirecting to the default (or first) dashboard, so I've added the option to have a `root_dashboard` which loads at the root url. May be useful for other people, so thought I'd do a PR. 

Any questions, please shout!
