### PR TITLE
Added suffix option for number widget

### DIFF
--- a/templates/project/widgets/number/number.html
+++ b/templates/project/widgets/number/number.html
@@ -1,6 +1,6 @@
 <h1 class="title" data-bind="title"></h1>
 
-<h2 class="value" data-bind="current | shortenedNumber | prepend prefix"></h2>
+<h2 class="value" data-bind="current | shortenedNumber | prepend prefix | append suffix"></h2>
 
 <p class="change-rate">
   <i data-bind-class="arrow"></i><span data-bind="difference"></span>


### PR DESCRIPTION
Added an option to append a suffix to the number in the number widget.  Done in the same was as prepend.  Useful for things like percentage (eg. 10%).
