### PR TITLE
allow send_event to be called from within modules

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -92,8 +92,8 @@ def send_event(id, body)
   body[:id] = id
   body[:updatedAt] ||= Time.now.to_i
   event = format_event(body.to_json)
-  settings.history[id] = event
-  settings.connections.each { |out| out << event }
+  Sinatra::Application.settings.history[id] = event
+  Sinatra::Application.settings.connections.each { |out| out << event }
 end
 
 def format_event(body)


### PR DESCRIPTION
resolves the error:
`undefined local variable or method `settings'`

when `send_event` is called from in a module
