### PR TITLE
Use any Tilt-supported view language: Haml, Slim, ERB, Liquid, etc.

### DIFF
--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -72,26 +72,33 @@ class AppTest < Dashing::Test
       get '/sampletv'
       assert_equal 200, last_response.status
       assert_include last_response.body, 'class="gridster"'
+      assert_include last_response.body, "DOCTYPE"
     end
   end
 
   begin
     require 'haml'
-    def test_get_haml
+
+    def test_get_haml_dashboard
       with_generated_project do |dir|
-        File.write(File.join(dir, "dashboards/hamltest.haml"), <<-HAML)
-.gridster
-  %ul
-    %li{data: {col: 1, row: 1, sizex: 1, sizey: 1}}
-      %div{data: {view: "Clock"}}
-      %i.icon-time.icon-background
-HAML
+        File.write(File.join(dir, 'dashboards/hamltest.haml'), '.gridster')
         get '/hamltest'
         assert_equal 200, last_response.status
         assert_include last_response.body, "class='gridster'"
       end
     end
+
+    def test_get_haml_widget
+      with_generated_project do |dir|
+        File.write(File.join(dir, 'widgets/clock/clock.haml'), '%h1 haml')
+        File.unlink(File.join(dir, 'widgets/clock/clock.html'))
+        get '/views/clock.html'
+        assert_equal 200, last_response.status
+        assert_include last_response.body, '<h1>haml</h1>'
+      end
+    end
   rescue LoadError
+    puts "[skipping haml tests because haml isn't installed]"
   end
 
   def test_get_nonexistent_dashboard


### PR DESCRIPTION
[Tilt](https://github.com/rtomayko/tilt), a "generic interface to multiple Ruby template engines", is built-in to Sinatra, so we can use it to support almost any template language for dashboards!

Related to #102 and #49.
