### PR TITLE
Persist and load history using a YAML file, so that server restarts don't lose pushed data

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -100,13 +100,27 @@ source.addEventListener 'error', (e)->
 
 source.addEventListener 'message', (e) =>
   data = JSON.parse(e.data)
-  if lastEvents[data.id]?.updatedAt != data.updatedAt
-    if Dashing.debugMode
-      console.log("Received data for #{data.id}", data)
-    lastEvents[data.id] = data
-    if widgets[data.id]?.length > 0
-      for widget in widgets[data.id]
-        widget.receiveData(data)
+
+  if data.restart
+    # Wait 20 seconds for server to restart.
+    # Every 5 seconds, check if the server is back up.
+    console.log "Server is restarting..."
+    setTimeout ->
+      setInterval ->
+        $.get('/up', (data) ->
+          console.log("Reloading page...")
+          location.reload(true)
+        ).fail(-> console.log("Waiting for server to start..."))
+      , 5000
+    , 20000
+  else
+    if lastEvents[data.id]?.updatedAt != data.updatedAt
+      if Dashing.debugMode
+        console.log("Received data for #{data.id}", data)
+      lastEvents[data.id] = data
+      if widgets[data.id]?.length > 0
+        for widget in widgets[data.id]
+          widget.receiveData(data)
 
 
 $(document).ready ->

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -63,6 +63,15 @@ get '/' do
   end
 end
 
+get '/up' do
+  status 200
+end
+
+get '/restart' do
+  send_restart_event
+  status 200
+end
+
 get '/:dashboard' do
   protected!
   if File.exist? File.join(settings.views, "#{params[:dashboard]}.erb")
@@ -108,6 +117,12 @@ def send_event(id, body)
   body[:updatedAt] ||= Time.now.to_i
   event = format_event(body.to_json)
   Sinatra::Application.settings.history[id] = event
+  Sinatra::Application.settings.connections.each { |out| out << event }
+end
+
+def send_restart_event
+  body = { restart: true }
+  event = format_event(body.to_json)
   Sinatra::Application.settings.connections.each { |out| out << event }
 end
 


### PR DESCRIPTION
This change adds an `at_exit` hook that saves all the event history in a YAML file. When dashing starts, it loads the events from this file if it exists.

We push data to dashing every hour, and don't want to lose this pushed data whenever dashing is deployed. (We host it on our own server, not Heroku.)
