### PR TITLE
Render titles correctly

### DIFF
--- a/templates/project/dashboards/sample.erb
+++ b/templates/project/dashboards/sample.erb
@@ -1,4 +1,4 @@
-<% content_for(:title) { "My super sweet dashboard" } %>
+<% content_for :title do %>My super sweet dashboard<% end %>
 <div class="gridster">
   <ul>
     <li data-row="1" data-col="1" data-sizex="2" data-sizey="1">

--- a/templates/project/dashboards/sampletv.erb
+++ b/templates/project/dashboards/sampletv.erb
@@ -8,7 +8,7 @@ $(function() {
 </script>
 
 
-<% content_for(:title) { "1080p dashboard" } %>
+<% content_for :title do %>1080p dashboard<% end %>
 
 <div class="gridster">
   <ul>

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -40,7 +40,7 @@ class AppTest < Dashing::Test
     assert_equal 200, last_response.status
     assert_equal 8, parse_data(@connection[0])['value']
   end
-  
+
   def test_redirect_to_default_dashboard
     with_generated_project do
       Sinatra::Application.settings.default_dashboard = 'test1'
@@ -73,6 +73,13 @@ class AppTest < Dashing::Test
       assert_equal 200, last_response.status
       assert_include last_response.body, 'class="gridster"'
       assert_include last_response.body, "DOCTYPE"
+    end
+  end
+
+  def test_page_title_set_correctly
+    with_generated_project do
+      get '/sampletv'
+      assert_include last_response.body, '<title>1080p dashboard</title>'
     end
   end
 


### PR DESCRIPTION
Dashboard titles were not being yielded to the layout for some reason. This PR changes the syntax slightly so that it works. Fixes #152
