### PR TITLE
use tmp dir for history file when running tests

### DIFF
--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require File.expand_path('../../lib/dashing', __FILE__)
+Sinatra::Application.settings.history_file = File.join(Dir.tmpdir, 'history.yml')
 
 class AppTest < Dashing::Test
   def setup


### PR DESCRIPTION
`at_exit` has interesting behavior with test-unit. It seems to get called before the tests even begin to run, so putting this assignment in the `setup` did not seem to work.

Perhaps using a `./tmp` for the history file would be more flexible down the road... or even just .gitignore it. here's my suggestion for now. 
