### PR TITLE
add stop command to dashing

### DIFF
--- a/bin/dashing
+++ b/bin/dashing
@@ -92,6 +92,12 @@ module Dashing
     end
     map "s" => :start
 
+    desc "stop", "Stops the thin server"
+    def stop
+      command = "bundle exec thin stop"
+      system(command)
+    end
+    
     desc "job JOB_NAME AUTH_TOKEN(optional)", "Runs the specified job. Make sure to supply your auth token if you have one set."
     def job(name, auth_token = "")
       Dir[File.join(Dir.pwd, 'lib/**/*.rb')].each {|file| require file }


### PR DESCRIPTION
While setting this up in our local environment, it occurred to me that a stop command would be useful. Particularly when running dashing using -d. While using thin stop works, I thought it might be nice to keep it inclusive to the gem.
