### PR TITLE
Security: authenticate / route as to not leak private dashboard urls

### DIFF
--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -56,6 +56,7 @@ get '/events', provides: 'text/event-stream' do
 end
 
 get '/' do
+  protected!
   begin
   redirect "/" + (settings.default_dashboard || first_dashboard).to_s
   rescue NoMethodError => e


### PR DESCRIPTION
Secures the `/` route as well. Does not redirect or leak dashboard urls to un-authenticated clients.
