### PR TITLE
Handle widgets with multiple capital letters

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -11,7 +11,7 @@ Batman.Filters.dashize = (str) ->
   dashes_rx1 = /([A-Z]+)([A-Z][a-z])/g;
   dashes_rx2 = /([a-z\d])([A-Z])/g;
 
-  return str.replace(dashes_rx1, '$1_$2').replace(dashes_rx2, '$1_$2').replace('_', '-').toLowerCase()
+  return str.replace(dashes_rx1, '$1_$2').replace(dashes_rx2, '$1_$2').replace(/_/g, '-').toLowerCase()
 
 Batman.Filters.shortenedNumber = (num) ->
   return num if isNaN(num)


### PR DESCRIPTION
This change allows widgets to have names like `AwesomeWidgetYes` and it will be given `awesome-widget-yes` instead of `awesome-widget_yes`

This seems like a bug, although it might be a breaking change for users already using widgets with multiple names. 
