### PR TITLE
remove direct dependency on thin as the rack implementation

### DIFF
--- a/bin/dashing
+++ b/bin/dashing
@@ -86,7 +86,7 @@ module Dashing
     def start(*args)
       port_option = args.include?('-p')? '' : ' -p 3030'
       args = args.join(" ")
-      command = "bundle exec thin -R config.ru start #{port_option} #{args}"
+      command = "bundle exec rackup config.ru #{port_option} #{args}"
       command.prepend "export JOB_PATH=#{options[:job_path]}; " if options[:job_path]
       system(command)
     end

--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency('coffee-script', '>=1.6.2')
   s.add_dependency('sinatra')
   s.add_dependency('sinatra-contrib')
-  s.add_dependency('thin')
   s.add_dependency('rufus-scheduler')
   s.add_dependency('thor')
   s.add_dependency('sprockets')

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -18,7 +18,7 @@ set :digest_assets, false
   settings.sprockets.append_path path
 end
 
-set server: 'thin', connections: [], history_file: 'history.yml'
+set connections: [], history_file: 'history.yml'
 
 # Persist history in tmp file at exit
 at_exit do

--- a/templates/project/Gemfile
+++ b/templates/project/Gemfile
@@ -1,6 +1,12 @@
 source 'https://rubygems.org'
 
 gem 'dashing'
+platform :jruby do
+  gem 'puma'
+end
+platform :ruby do
+  gem 'thin'
+end
 
 ## Remove this if you don't need a twitter widget.
 gem 'twitter'


### PR DESCRIPTION
the main reason for this is to allow compatibility with jruby as thin is not really compatible out of the box with jruby.

the change basically removes thin from the dashing.gemspec file and moves it to the dashboard's Gemfile where it is wrapped in a `platform :ruby` block and instead of using 'thin start' it uses 'rackup' to start the server.

initial problems:
 - current projects may revert back to webbrick on up grading as there Gemfile won't have been changed
 - the dashing stop command assumes 'thin' as there doesn't seem to be an equivalent `rackup`, guess may have to use the rack.pid file and kill the process

