### PR TITLE
Allow dashing to run on sub-path by using relative urls

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -92,7 +92,7 @@ Dashing.widgets = widgets = {}
 Dashing.lastEvents = lastEvents = {}
 Dashing.debugMode = false
 
-source = new EventSource('/events')
+source = new EventSource('events')
 source.addEventListener 'open', (e) ->
   console.log("Connection opened")
 


### PR DESCRIPTION
A minor change that solved our only problem with running dashing on a sub-path.
