### PR TITLE
Fixes event connection close error never re-establishes connection.

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -102,7 +102,7 @@ source.addEventListener 'error', (e)->
     console.log("Connection closed")
     setTimeout (->
       window.location.reload()
-    ), 10000
+    ), 5*60*1000
 
 source.addEventListener 'message', (e) ->
   data = JSON.parse(e.data)


### PR DESCRIPTION
This fixes a problem when EventSource sends a closed event and closes the connection, we will never get the dashboard to receive new events unless the page is refreshed. This happens when Dashing server crashes and restarts again, a EventSource closed event is sent.

Instead, when it get's a connection closed event, it reloads the current page, which will enable the listener on the 'open' event and re-establish a new connection.

Also fixes an error on checking the readyState of eventsource.
