### PR TITLE
Fancy-up the Graph widget.

### DIFF
--- a/templates/project/widgets/graph/README.md
+++ b/templates/project/widgets/graph/README.md
@@ -8,7 +8,7 @@ Supported HTML data fields
 --------------------------
 
 * `data-title`: Title to display.
-* `data-displayedValue`: If provided, then the value to display overtop of the graph.  If not
+* `data-displayed-value`: If provided, then the value to display overtop of the graph.  If not
   provided, then the most recent value will be used if there is only one series.
 * `data-renderer`: Any valid Rickshaw renderer, including 'area', 'line', 'bar', 'scatterplot'.
 * `data-stroke`: If "true", then area graphs will be drawn with a stroke.
@@ -18,6 +18,13 @@ Supported HTML data fields
   `data-colors="#ccc:#ddd:#eee"`)
 * `data-stroke-colors`: A ":" separated list of colors to use for strokes.
 * `data-legend`: If "true", then a legend will be added to your graph.
+* `data-summary-method` determines how the value shown in the graph is computed.  If
+  `data-displayed-value` is set, this is ignored.  Otherwise this should be one of:
+  * "last" - Default - If there is only one series, show the most recent value from that series.
+  * "sum" - Sum of all values across all series.
+  * "sumLast" - Sum of last values across all series.
+  * "highest" - For stacked graphs, the highest single data point based on the sum of all series.
+    For unstacked graphs, the highest single data point of any series.
 
 Passing Data
 ------------

--- a/templates/project/widgets/graph/README.md
+++ b/templates/project/widgets/graph/README.md
@@ -17,7 +17,11 @@ Supported HTML data fields
   provided than there are series to graph, then pleasing colors will be automatically chosen.  (e.g.:
   `data-colors="#ccc:#ddd:#eee"`)
 * `data-stroke-colors`: A ":" separated list of colors to use for strokes.
+* `data-color-scheme`: One of "rainbow", "near-rainbow", "compliment", "default".  Controls how
+  default colors are assigned.
+* `data-default-alpha`: Alpha for default colors.
 * `data-legend`: If "true", then a legend will be added to your graph.
+# `data-min` and `data-max`: Set the highest and lowest values of the y-axis.
 * `data-summary-method` determines how the value shown in the graph is computed.  If
   `data-displayed-value` is set, this is ignored.  Otherwise this should be one of:
   * "last" - Default - If there is only one series, show the most recent value from that series.

--- a/templates/project/widgets/graph/README.md
+++ b/templates/project/widgets/graph/README.md
@@ -1,0 +1,68 @@
+Graphing Widget
+===============
+
+The graphing widget shows graphs using the Rickshaw graphing library.  The names of data fields
+should be (vaguely) familiar if you've used Rickshaw before.
+
+Supported HTML data fields
+--------------------------
+
+* `data-title`: Title to display.
+* `data-displayedValue`: If provided, then the value to display overtop of the graph.  If not
+  provided, then the most recent value will be used if there is only one series.
+* `data-renderer`: Any valid Rickshaw renderer, including 'area', 'line', 'bar', 'scatterplot'.
+* `data-stroke`: If "true", then area graphs will be drawn with a stroke.
+* `data-unstack`: If "true", then area and bar graphs will be "unstacked".
+* `data-colors`: A ":" separated list of colors to use for each plot.  If there are fewer colors
+  provided than there are series to graph, then pleasing colors will be automatically chosen.  (e.g.:
+  `data-colors="#ccc:#ddd:#eee"`)
+* `data-stroke-colors`: A ":" separated list of colors to use for strokes.
+* `data-legend`: If "true", then a legend will be added to your graph.
+
+Passing Data
+------------
+
+Data can be provided in a number of formats.  Data can be passed as a series of points:
+
+    points = [{x:1, y: 4}, {x:2, y:27}, {x:3, y:6}]
+    send_event('convergence', points: points)
+
+Note that the `x` values are interpreted as unix timestamps.  Data can also be passed as full-on
+Rickshaw-style series:
+
+    series = [
+        {
+            name: "Convergence",
+            data: [{x:1, y: 4}, {x:2, y:27}, {x:3, y:6}]
+        },
+        {
+            name: "Divergence",
+            data: [{x:1, y: 5}, {x:2, y:2}, {x:3, y:9}]
+        }
+    ]
+    send_event('convergence', series: series)
+
+You can even provide colors and strokes here, which will override the values defined in the HTML.
+Or data can be passed as Graphite-style data:
+
+    graphite = [
+      {
+        target: "stats_counts.http.ok",
+        datapoints: [[10, 1378449600], [40, 1378452000], [53, 1378454400], [63, 1378456800], [27, 1378459200]]
+      },
+      {
+        target: "stats_counts.http.err",
+        datapoints: [[0, 1378449600], [4, 1378452000], [nil, 1378454400], [3, 1378456800], [0, 1378459200]]
+      }
+    ]
+    send_event('http', series: graphite)
+
+You can even send data as JSON strings, straight from Graphite:
+
+    require "rest-client"
+    SCHEDULER.every '10s', :first_in => 0 do
+        target = "aliasSub(summarize(stats_counts.http.*%2C%2720min%27)%2C%27%5E.*http.(%5Cw*).*%27%2C%27%5C1%27)"
+        url = "http://graphteserver.local:8000/render?format=json&target=#{target}&from=today"
+        graphite_json_data = RestClient.get url
+        send_event 'http_counts', { series: graphite_json_data }
+    end

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -6,14 +6,12 @@ class Dashing.Graph extends Dashing.Widget
 
     # Return the value supplied if there is one.
     if @get('displayedValue') != null and @get('displayedValue') != undefined
-      console.log "Using displayedValue"
       answer = @get('displayedValue')
 
     if answer == null
       # Compute a value to return based on the summaryMethod
       series = @_parseData {points: @get('points'), series: @get('series')}
       if series?.length > 0
-        console.log "Summary Method", @get('summaryMethod')
         switch @get('summaryMethod')
           when "sum"
             answer = 0

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -258,7 +258,6 @@ class Dashing.Graph extends Dashing.Widget
       luminance = hsl[2]
       luminanceSource = if (luminance < 0.6) then 0.9 else 0.1
       luminances = interpolate luminanceSource, luminance, (series.length + 1)
-      console.log "#{self.get 'id'}", series.length, luminance, luminances
 
       for index in [0...series.length]
         hsl[1] = saturations[index]

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -16,7 +16,7 @@ class Dashing.Graph extends Dashing.Widget
     return ''
 
   ready: ->
-    @colors = @get('colors').split(':') if @get('colors')
+    @assignedColors = @get('colors').split(':') if @get('colors')
     @strokeColors = @get('strokeColors').split(':') if @get('strokeColors')
 
     @graph = @_createGraph()
@@ -121,19 +121,15 @@ class Dashing.Graph extends Dashing.Widget
   # Update the color assignments for a series.  This will assign colors to any data that
   # doesn't have a color already.
   _updateColors: (series) ->
-    defaultColors = @colors
-
     # If no colors were provided, or of there aren't enough colors, then generate a set of
     # colors to use.
-    if !defaultColors or defaultColors.length < series.length
-      if @defaultColors?.length != series.length
-        @defaultColors = computeDefaultColors @node, series
-      defaultColors = @defaultColors
+    if !@defaultColors or @defaultColors?.length != series.length
+      @defaultColors = computeDefaultColors @node, series
 
     for subseries, index in series
       # Preferentially pick supplied colors instead of defaults, but don't overwrite a color
       # if one was supplied with the data.
-      subseries.color ?= @colors?[index] or defaultColors[index]
+      subseries.color ?= @assignedColors?[index] or @defaultColors[index]
       subseries.stroke ?= @strokeColors?[index] or "#000"
 
   # Convert a collection of Graphite data points into data that Rickshaw will understand.

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -41,11 +41,11 @@ class Dashing.Graph extends Dashing.Widget
               data = series[0].data
               answer = data[data.length - 1].y
             else
+              # Otherwise just return nothing.
               answer = ''
       else
         answer = '-'
 
-    # Otherwise just return nothing.
     return answer
 
   ready: ->

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -154,8 +154,8 @@ class Dashing.Graph extends Dashing.Widget
       luminance = hsl[2]
 
       # `quotient` should be at least `series.length + 1`, since we want to avoid pure
-      # black or pure white bars.  `+3` seems to be visually pleasing.
-      quotient = (series.length + 3)
+      # black or pure white bars.  Larger values result in graphs that are harder to read.
+      quotient = (series.length + 1)
       if luminance < 0.6
         # Choose colors that are lighter than the background
         delta = (1.0 - luminance) / quotient

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -1,36 +1,282 @@
 class Dashing.Graph extends Dashing.Widget
 
+  # Retrieve the `current` value of the graph.
   @accessor 'current', ->
-    return @get('displayedValue') if @get('displayedValue')
-    points = @get('points')
-    if points
-      points[points.length - 1].y
+    # Return the value supplied if there is one.
+    if @get('displayedValue') != null and @get('displayedValue') != undefined
+      return @get('displayedValue')
+
+    # Otherwise if there's only one series, pick the most recent value from the series.
+    series = @_parseData {points: @get('points'), series: @get('series')}
+    if series?.length == 1 and series[0].data?.length > 0
+      data = series[0].data
+      return data[data.length - 1].y
+
+    # Otherwise just return nothing.
+    return ''
 
   ready: ->
-    container = $(@node).parent()
-    # Gross hacks. Let's fix this.
-    width = (Dashing.widget_base_dimensions[0] * container.data("sizex")) + Dashing.widget_margins[0] * 2 * (container.data("sizex") - 1)
-    height = (Dashing.widget_base_dimensions[1] * container.data("sizey"))
-    @graph = new Rickshaw.Graph(
-      element: @node
-      width: width
-      height: height
-      renderer: @get("graphtype")
-      series: [
-        {
-        color: "#fff",
-        data: [{x:0, y:0}]
-        }
-      ]
-    )
+    @colors = @get('colors').split(':') if @get('colors')
+    @strokeColors = @get('strokeColors').split(':') if @get('strokeColors')
 
-    @graph.series[0].data = @get('points') if @get('points')
-
-    x_axis = new Rickshaw.Graph.Axis.Time(graph: @graph)
-    y_axis = new Rickshaw.Graph.Axis.Y(graph: @graph, tickFormat: Rickshaw.Fixtures.Number.formatKMBT)
+    @graph = @_createGraph()
     @graph.render()
 
+  # Handle new data from Dashing.
   onData: (data) ->
-    if @graph
-      @graph.series[0].data = data.points
-      @graph.render()
+    @_parseData data
+    @graph?.render()
+
+  # Create a new Rickshaw graph.
+  _createGraph: ->
+    $node = $(@node)
+    $container = $node.parent()
+    # Gross hacks. Let's fix this.
+    width = (Dashing.widget_base_dimensions[0] * $container.data("sizex")) + Dashing.widget_margins[0] * 2 * ($container.data("sizex") - 1)
+    height = (Dashing.widget_base_dimensions[1] * $container.data("sizey"))
+
+    if @get("legend")
+      # Shave 20px off the bottom of the graph for the legend
+      height -= 20
+
+    $graph = $("<div style='height: #{height}px;'></div>")
+    $node.append $graph
+    graph = new Rickshaw.Graph(
+      element:  $graph.get(0),
+      renderer: @get('renderer') or 'area',
+      stroke:   !!@get('stroke'),
+      width:  width,
+      height:   height,
+      series:   @_parseData {points: @get('points'), series: @get('series')}
+    )
+    graph.renderer.unstack = !!@get('unstack')
+
+    x_axis = new Rickshaw.Graph.Axis.Time(graph: graph)
+    y_axis = new Rickshaw.Graph.Axis.Y(graph: graph, tickFormat: Rickshaw.Fixtures.Number.formatKMBT)
+
+    if @get("legend")
+      # Add a legend
+      $legendDiv = $("<div style='width: #{width}px;'></div>")
+      $node.append($legendDiv)
+      legend = new Rickshaw.Graph.Legend {
+        graph: graph
+        element: $legendDiv.get(0)
+      }
+
+    return graph
+
+  # Parse a {series, points} object with new data from Dashing.
+  #
+  # If there is a graph, this will update it.  If not, this will return a new `series` object,
+  # suitable for creating a new graph.
+  _parseData: (data) ->
+    series = @graph?.series or []
+
+    # Figure out what kind of data we've been passed
+    if data.series
+      dataSeries = if isString(data.series) then JSON.parse data.series else data.series
+      for subseries, index in dataSeries
+        series[index] = @_parseSeries subseries
+
+    else if data.points
+      points = data.points
+      if isString(points) then points = JSON.parse points
+
+      if points[0]? and !points[0].x?
+        # Not already in Rickshaw format; assume graphite data
+        points = graphiteDataToRickshaw(points)
+
+      series[0] = {data: points}
+    else
+      # No data - create a dummy series to keep Rickshaw happy
+      series = [{data: [{x:0, y:0}]}]
+
+    @_updateColors(series)
+
+    return series
+
+  # Parse a series of data from an array passed to `_parseData()`.
+  # This accepts both Graphite and Rickshaw style data sets.
+  _parseSeries: (series) ->
+    if series.datapoints?
+      # This is a Graphite series
+      answer = {
+        name: series.target
+        data: graphiteDataToRickshaw series.datapoints
+        color: series.color
+        stroke: series.stroke
+      }
+    else if series.data?
+      # Rickshaw data.  Need to clone, otherwise we could end up with multiple graphs sharing
+      # the same data, and Rickshaw really doesn't like that.
+      answer = {
+        name:   series.name
+        data:   series.data
+        color:  series.color
+        stroke: series.stroke
+      }
+    else
+      throw new Error("Unknown data series: #{series}")
+
+  # Update the color assignments for a series.  This will assign colors to any data that
+  # doesn't have a color already.
+  _updateColors: (series) ->
+    defaultColors = @colors
+
+    # If no colors were provided, or of there aren't enough colors, then generate a set of
+    # colors to use.
+    if !defaultColors or defaultColors.length < series.length
+      if @defaultColors?.length != series.length
+        @defaultColors = computeDefaultColors @node, series
+      defaultColors = @defaultColors
+
+    for subseries, index in series
+      # Preferentially pick supplied colors instead of defaults, but don't overwrite a color
+      # if one was supplied with the data.
+      subseries.color ?= @colors?[index] or defaultColors[index]
+      subseries.stroke ?= @strokeColors?[index] or "#000"
+
+  # Convert a collection of Graphite data points into data that Rickshaw will understand.
+  graphiteDataToRickshaw = (datapoints) ->
+    answer = []
+    for datapoint in datapoints
+      # Need to convert potential nulls from Graphite into a real number for Rickshaw.
+      answer.push {x: datapoint[1], y: (datapoint[0] or 0)}
+    answer
+
+  # Compute a pleasing set of default colors.  This works by starting with the background color,
+  # and picking colors of intermediate luminance between the background and white (or the
+  # background and black, for light colored backgrounds.)  We use the brightest color for the
+  # first series, because then multiple series will appear to blend in to the background.
+  computeDefaultColors = (node, series) ->
+    defaultColors = []
+
+    # Use a neutral color if we can't get the background-color for some reason.
+    backgroundColor = parseColor($(node).css('background-color')) or [50, 50, 50, 1.0]
+    if backgroundColor
+      hsl = rgbToHsl backgroundColor
+      luminance = hsl[2]
+
+      # `quotient` should be at least `series.length + 1`, since we want to avoid pure
+      # black or pure white bars.  `+3` seems to be visually pleasing.
+      quotient = (series.length + 3)
+      if luminance < 0.6
+        # Choose colors that are lighter than the background
+        delta = (1.0 - luminance) / quotient
+      else
+        # Choose colors that are darker than the background
+        delta = -(luminance / quotient)
+
+      for index in [0...series.length]
+        hsl[2] = luminance + (series.length - index) * delta
+        defaultColors[index] = rgbToColor hslToRgb(hsl)
+
+    return defaultColors
+
+
+
+# Helper functions
+# ================
+isString = (obj) ->
+  return toString.call(obj) is "[object String]"
+
+# Parse a `rgb(x,y,z)` or `rgba(x,y,z,a)` string.
+parseRgbaColor = (colorString) ->
+  match = /^rgb\(\s*([\d]+)\s*,\s*([\d]+)\s*,\s*([\d]+)\s*\)/.exec(colorString)
+  if match
+    return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3]), 1.0]
+
+  match = /^rgba\(\s*([\d]+)\s*,\s*([\d]+)\s*,\s*([\d]+)\s*,\s*([\d]+)\s*\)/.exec(colorString)
+  if match
+    return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3]), parseInt(match[4])]
+
+  return null
+
+# Parse a color string as RGBA
+parseColor = (colorString) ->
+  answer = null
+
+  # Try to use the browser to parse the color for us.
+  div = document.createElement('div')
+  div.style.color = colorString
+  if div.style.color
+    answer = parseRgbaColor div.style.color
+
+  if !answer
+    match = /^#([\da-fA-F]{2})([\da-fA-F]{2})([\da-fA-F]{2})/.exec(colorString)
+    if match then answer = [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16), 1.0]
+
+  if !answer
+    match = /^#([\da-fA-F])([\da-fA-F])([\da-fA-F])/.exec(colorString)
+    if match then answer = [parseInt(match[1], 16) * 0x11, parseInt(match[2], 16) * 0x11, parseInt(match[3], 16) * 0x11, 1.0]
+
+  if !answer then answer = parseRgbaColor colorString
+
+  return answer
+
+# Convert an RGB or RGBA color to a CSS color.
+rgbToColor = (rgb) ->
+  if (!3 of rgb) or (rgb[3] == 1.0)
+    return "rgb(#{rgb[0]},#{rgb[1]},#{rgb[2]})"
+  else
+    return "rgba(#{rgb[0]},#{rgb[1]},#{rgb[2]},#{rgb[3]})"
+
+# Adapted from http://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c
+#
+# Converts an RGBA color value to HSLA. Conversion formula
+# adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+# Assumes r, g, and b are contained in the set [0, 255] and
+# a in [0, 1].  Returns h, s, l, a in the set [0, 1].
+#
+# Returns the HSLA representation as an array.
+rgbToHsl = (rgba) ->
+  [r,g,b,a] = rgba
+  r /= 255
+  g /= 255
+  b /= 255
+  max = Math.max(r, g, b)
+  min = Math.min(r, g, b)
+  l = (max + min) / 2
+
+  if max == min
+    h = s = 0 # achromatic
+  else
+    d = max - min
+    s = if l > 0.5 then d / (2 - max - min) else d / (max + min)
+    switch max
+      when r then h = (g - b) / d + (g < b ? 6 : 0)
+      when g then h = (b - r) / d + 2
+      when b then h = (r - g) / d + 4
+    h /= 6;
+
+  return [h, s, l, a]
+
+# Adapted from http://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c
+#
+# Converts an HSLA color value to RGBA. Conversion formula
+# adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+# Assumes h, s, l, and a are contained in the set [0, 1] and
+# returns r, g, and b in the set [0, 255] and a in [0, 1].
+#
+# Retunrs the RGBA representation as an array.
+hslToRgb = (hsla) ->
+  [h,s,l,a] = hsla
+  if s is 0
+    r = g = b = l # achromatic
+  else
+    hue2rgb = (p, q, t) ->
+      if(t < 0)   then t += 1
+      if(t > 1)   then t -= 1
+      if(t < 1/6) then return p + (q - p) * 6 * t
+      if(t < 1/2) then return q
+      if(t < 2/3) then return p + (q - p) * (2/3 - t) * 6
+      return p
+
+    q = if l < 0.5 then l * (1 + s) else l + s - l * s
+    p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1/3)
+    g = hue2rgb(p, q, h)
+    b = hue2rgb(p, q, h - 1/3)
+
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), a]
+

--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -43,7 +43,7 @@ class Dashing.Graph extends Dashing.Widget
     $node.append $graph
     graph = new Rickshaw.Graph(
       element:  $graph.get(0),
-      renderer: @get('renderer') or 'area',
+      renderer: @get('renderer') or @get('graphtype') or 'area',
       stroke:   !!@get('stroke'),
       width:  width,
       height:   height,

--- a/templates/project/widgets/graph/graph.scss
+++ b/templates/project/widgets/graph/graph.scss
@@ -4,7 +4,7 @@
 $background-color:  #dc5945;
 
 $title-color:       rgba(255, 255, 255, 0.7);
-$moreinfo-color:    rgba(255, 255, 255, 0.3);
+$moreinfo-color:    rgba(255, 255, 255, 0.5);
 $tick-color:        rgba(0, 0, 0, 0.4);
 
 
@@ -16,11 +16,14 @@ $tick-color:        rgba(0, 0, 0, 0.4);
   background-color: $background-color;
   position: relative;
 
+  .rickshaw_graph {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+  }
 
   svg {
     position: absolute;
-    opacity: 0.4;
-    fill-opacity: 0.4;
     left: 0px;
     top: 0px;
   }
@@ -55,11 +58,46 @@ $tick-color:        rgba(0, 0, 0, 0.4);
   .y_ticks {
     font-size: 20px;
     fill: $tick-color;
-    fill-opacity: 1;
+    text {
+      opacity: 0.5;
+    }
   }
 
   .domain {
     display: none;
+  }
+
+  .rickshaw_legend {
+    position: absolute;
+    left: 0px;
+    bottom: 0px;
+    white-space: nowrap;
+    overflow-x: hidden;
+    font-size: 15px;
+    height: 20px;
+
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
+      text-align: center;
+    }
+
+    ul li {
+      display: inline;
+    }
+
+    .swatch {
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      margin-left: 5px;
+    }
+
+    .label {
+      display: inline-block;
+      margin-left: 5px;
+    }
   }
 
 }


### PR DESCRIPTION
![screen shot 2013-09-06 at 3 32 43 pm](https://f.cloud.github.com/assets/1771003/1099371/6ad4fe72-1735-11e3-84d6-1f781bbe667d.png)

This adds a number of features to the Graph widget.  As much as possible, I tried to keep the names of parameters the same as their Rickshaw counterparts (hence the addition of "renderer" as a parameter, in place of "graphtype").  The idea is to make this as painless as possible for people experienced with Rickshaw.

All of the below is also documented in a README.md file in the Widget directory.
## Supported HTML data fields
- `data-title`: Title to display.
- `data-displayedValue`: If provided, then the value to display overtop of the graph.  If not
  provided, then the most recent value will be used if there is only one series.
- `data-renderer`: Any valid Rickshaw renderer, including 'area', 'line', 'bar', 'scatterplot'.
- `data-stroke`: If "true", then area graphs will be drawn with a stroke.
- `data-unstack`: If "true", then area and bar graphs will be "unstacked".
- `data-colors`: A ":" separated list of colors to use for each plot.  If there are fewer colors
  provided than there are series to graph, then pleasing colors will be automatically chosen.  (e.g.:
  `data-colors="#ccc:#ddd:#eee"`)
- `data-stroke-colors`: A ":" separated list of colors to use for strokes.
- `data-legend`: If "true", then a legend will be added to your graph.
## Passing Data

Data can be provided in a number of formats.  Data can be passed as a series of points:

```
points = [{x:1, y: 4}, {x:2, y:27}, {x:3, y:6}]
send_event('convergence', points: points)
```

Note that the `x` values are interpreted as unix timestamps.  Data can also be passed as full-on
Rickshaw-style series:

```
series = [
    {
        name: "Convergence",
        data: [{x:1, y: 4}, {x:2, y:27}, {x:3, y:6}]
    },
    {
        name: "Divergence",
        data: [{x:1, y: 5}, {x:2, y:2}, {x:3, y:9}]
    }
]
send_event('convergence', series: series)
```

You can even provide colors and strokes here, which will override the values defined in the HTML.
Or data can be passed as Graphite-style data:

```
graphite = [
  {
    target: "stats_counts.http.ok",
    datapoints: [[10, 1378449600], [40, 1378452000], [53, 1378454400], [63, 1378456800], [27, 1378459200]]
  },
  {
    target: "stats_counts.http.err",
    datapoints: [[0, 1378449600], [4, 1378452000], [nil, 1378454400], [3, 1378456800], [0, 1378459200]]
  }
]
send_event('http', series: graphite)
```

You can even send data as JSON strings, straight from Graphite:

```
require "rest-client"
SCHEDULER.every '10s', :first_in => 0 do
    target = "aliasSub(summarize(stats_counts.http.*%2C%2720min%27)%2C%27%5E.*http.(%5Cw*).*%27%2C%27%5C1%27)"
    url = "http://graphteserver.local:8000/render?format=json&target=#{target}&from=today"
    graphite_json_data = RestClient.get url
    send_event 'http_counts', { series: graphite_json_data }
end
```
