### PR TITLE
make updated-at transparency level of graph widget consistent with other widgets

### DIFF
--- a/templates/project/widgets/graph/graph.scss
+++ b/templates/project/widgets/graph/graph.scss
@@ -62,4 +62,8 @@ $tick-color:        rgba(0, 0, 0, 0.4);
     display: none;
   }
 
+  .updated-at {
+    color: rgba(0, 0, 0, 0.3);
+  }
+
 }


### PR DESCRIPTION
Most widgets define a transparency level for the "Updated At" text label. The graph widget is missing such definition, resulting in an inconsistent display when showing graph widgets with other widgets on the same dashboard. This PR applies a consistent transparency level to the graph widget.
