### PR TITLE
gitignore history.yml

### DIFF
--- a/templates/project/.gitignore
+++ b/templates/project/.gitignore
@@ -1,1 +1,2 @@
 *DS_STORE
+history.yml


### PR DESCRIPTION
Looks like `history.yml` is a dynamically generated file. No point in having it version controlled.
