### PR TITLE
float support for number widget

### DIFF
--- a/templates/project/widgets/number/number.coffee
+++ b/templates/project/widgets/number/number.coffee
@@ -3,8 +3,8 @@ class Dashing.Number extends Dashing.Widget
 
   @accessor 'difference', ->
     if @get('last')
-      last = parseInt(@get('last'))
-      current = parseInt(@get('current'))
+      last = parseFloat(@get('last'))
+      current = parseFloat(@get('current'))
       if last != 0
         diff = Math.abs(Math.round((current - last) / last * 100))
         "#{diff}%"
@@ -13,7 +13,7 @@ class Dashing.Number extends Dashing.Widget
 
   @accessor 'arrow', ->
     if @get('last')
-      if parseInt(@get('current')) > parseInt(@get('last')) then 'icon-arrow-up' else 'icon-arrow-down'
+      if parseFloat(@get('current')) > parseFloat(@get('last')) then 'icon-arrow-up' else 'icon-arrow-down'
 
   onData: (data) ->
     if data.status


### PR DESCRIPTION
Any reason for number widget to not support decimal points? If so, feel free to close this PR (and rename to Integer widget? :P). Otherwise, I think this enables functionality for floats without affecting anything for ints.
