### PR TITLE
Updated to Rufus-Scheduler 3.0 syntax

### DIFF
--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sinatra')
   s.add_dependency('sinatra-contrib')
   s.add_dependency('thin')
-  s.add_dependency('rufus-scheduler')
+  s.add_dependency('rufus-scheduler', '>=3.0.0')
   s.add_dependency('thor')
   s.add_dependency('sprockets')
   s.add_dependency('rack')

--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -21,11 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sinatra')
   s.add_dependency('sinatra-contrib')
   s.add_dependency('thin')
-<<<<<<< HEAD
   s.add_dependency('rufus-scheduler', '>=3.0.0')
-=======
-  s.add_dependency('rufus-scheduler', '~> 2.0')
->>>>>>> upstream/master
   s.add_dependency('thor')
   s.add_dependency('sprockets')
   s.add_dependency('rack')

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -7,7 +7,7 @@ require 'sass'
 require 'json'
 require 'yaml'
 
-SCHEDULER = Rufus::Scheduler.start_new
+SCHEDULER = Rufus::Scheduler.new
 
 set :root, Dir.pwd
 


### PR DESCRIPTION
- modified gemspec to require rufus-scheduler >= 3.0.0
- modified scheduler call to use .new instead of previous .start_new syntax
