### PR TITLE
set auth_token to a generated UUID if AUTH_TOKEN not passed in ENV

### DIFF
--- a/templates/project/config.ru
+++ b/templates/project/config.ru
@@ -1,5 +1,5 @@
 require 'dashing'
-require 'SecureRandom'
+require 'securerandom'
 
 configure do
   set :auth_token, ENV['AUTH_TOKEN'] || SecureRandom.uuid

--- a/templates/project/config.ru
+++ b/templates/project/config.ru
@@ -1,7 +1,8 @@
 require 'dashing'
+require 'SecureRandom'
 
 configure do
-  set :auth_token, 'YOUR_AUTH_TOKEN'
+  set :auth_token, ENV['AUTH_TOKEN'] || SecureRandom.uuid
 
   helpers do
     def protected!


### PR DESCRIPTION
Fixes issue #191. If an `AUTH_TOKEN` ENV variable is not present, uses `SecureRandom.uuid` to generate a UUID to use as the token.

`AUTH_TOKEN='foobarbaz' dashing start` →`settings.auth_token == 'foobarbaz'`
`dashing start` → `settings.auth_token == 'some-random-uuid-string'`
