### PR TITLE
Fix broken favicon link in default layout.erb

### DIFF
--- a/templates/project/dashboards/layout.erb
+++ b/templates/project/dashboards/layout.erb
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/assets/application.css">
 
   <link href='//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
-  <link rel="icon" href="/assets/favicon.ico">
+  <link rel="icon" href="/favicon.ico">
 
 </head>
   <body>


### PR DESCRIPTION
The default favicon is in public/favicon.ico, and as such will not be served under /assets/.
