### PR TITLE
added an extra route (/latest) and making a call to that to fetch latest

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -95,6 +95,7 @@ Dashing.debugMode = false
 source = new EventSource('events')
 source.addEventListener 'open', (e) ->
   console.log("Connection opened", e)
+  $.get('latest')
 
 source.addEventListener 'error', (e)->
   console.log("Connection error", e)

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -50,7 +50,6 @@ get '/events', provides: 'text/event-stream' do
   response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
   stream :keep_open do |out|
     settings.connections << out
-    out << latest_events
     out.callback { settings.connections.delete(out) }
   end
 end
@@ -62,6 +61,11 @@ get '/' do
   rescue NoMethodError => e
     raise Exception.new("There are no dashboards in your dashboard directory.")
   end
+end
+
+get '/latest' do
+  settings.connections.each { |out| out << latest_events }
+  200
 end
 
 get '/:dashboard' do


### PR DESCRIPTION
Noticed history wasn't loading after restarting the server.  Looks like it was trying to be passed in the /events call, but wasn't working.  I added a new route (/latest) which is then hit from the client side after a connection is established and the latest data is then fed to the client.
