### PR TITLE
Correct arrows in default numbers widget

### DIFF
--- a/templates/project/widgets/number/number.coffee
+++ b/templates/project/widgets/number/number.coffee
@@ -13,7 +13,12 @@ class Dashing.Number extends Dashing.Widget
 
   @accessor 'arrow', ->
     if @get('last')
-      if parseInt(@get('current')) > parseInt(@get('last')) then 'icon-arrow-up' else 'icon-arrow-down'
+      arrow_direction = 'none'
+      if parseInt(@get('current')) > parseInt(@get('last'))
+        arrow_direction ='up' 
+      else if parseInt(@get('current')) < parseInt(@get('last'))
+        arrow_direction = 'down'
+      return 'icon-arrow-' + arrow_direction 
 
   onData: (data) ->
     if data.status


### PR DESCRIPTION
This aims to resolve the issue described in issue #275 

I cannot find an equals sign or equivalent in the font awesome web font so have gone with an unavailable class name so that no icon is displayed.
