### PR TITLE
Updates the Number widget to use floats or integers

### DIFF
--- a/templates/project/widgets/number/number.coffee
+++ b/templates/project/widgets/number/number.coffee
@@ -3,8 +3,8 @@ class Dashing.Number extends Dashing.Widget
 
   @accessor 'difference', ->
     if @get('last')
-      last = parseInt(@get('last'))
-      current = parseInt(@get('current'))
+      last = @parseValue(@get('last'))
+      current = @parseValue(@get('current'))
       if last != 0
         diff = Math.abs(Math.round((current - last) / last * 100))
         "#{diff}%"
@@ -13,7 +13,7 @@ class Dashing.Number extends Dashing.Widget
 
   @accessor 'arrow', ->
     if @get('last')
-      if parseInt(@get('current')) > parseInt(@get('last')) then 'icon-arrow-up' else 'icon-arrow-down'
+      if @parseValue(@get('current')) > @parseValue(@get('last')) then 'icon-arrow-up' else 'icon-arrow-down'
 
   onData: (data) ->
     if data.status
@@ -22,3 +22,8 @@ class Dashing.Number extends Dashing.Widget
         c.replace /\bstatus-\S+/g, ''
       # add new class
       $(@get('node')).addClass "status-#{data.status}"
+
+  parseValue: (number) ->
+    if number == parseInt(number, 10) then parseInt(number) else parseFloat(number)
+
+


### PR DESCRIPTION
The currently implemented number widget only supports integers when calculating the difference.  We were using it with NewRelic's response time metric which is returned in milliseconds but we wanted to show in seconds (200ms vs 0.200s).  However, since the JS used parseInt it changed the floats to zero (0) and never showed a valid difference.  There were a couple of pull requests already that just changed parseInt to parseFloat.  This PR updated the JS to detect if the supplied values are floats or integers and then use the appropriate parser for the value, thereby, supporting both types.