### PR TITLE
Update lastEvents if a widget exists.

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -109,8 +109,8 @@ source.addEventListener 'message', (e) ->
   if lastEvents[data.id]?.updatedAt != data.updatedAt
     if Dashing.debugMode
       console.log("Received data for #{data.id}", data)
-    lastEvents[data.id] = data
     if widgets[data.id]?.length > 0
+      lastEvents[data.id] = data
       for widget in widgets[data.id]
         widget.receiveData(data)
 


### PR DESCRIPTION
We have been running into an issue where widgets on a webpage do not get updated with new data, while the updatedAt value gets updated in the browser.  This is because lastEvents is set OUTSIDE of the if block.  If no widget can be resolved by data.id (namely, widgets[data.id]?.length > 0 is evaluated to be false), then dashing will never update the widgets with data coming in from EventSource, since the lastEvents updatedAt value for the widget ID is the same as the incoming data's updatedAt value.

With the code fix in this pull request, dashing will refresh widgets on the next GET Events fired from the EventSource/SSE cycle.
