### PR TITLE
add error string when widget not rendered

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -117,6 +117,7 @@ get '/views/:widget?.html' do
     file = File.join(settings.root, "widgets", params[:widget], "#{params[:widget]}.#{suffix}")
     return engines.first.new(file).render if File.exist? file
   end
+  "Drats! Unable to find a widget file named: #{params[:widget]} to render."
 end
 
 def send_event(id, body, target=nil)

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -137,6 +137,14 @@ class AppTest < Dashing::Test
     end
   end
 
+  def test_get_nonexistent_widget
+    with_generated_project do
+      get '/views/nowidget.html'
+      assert_equal 200, last_response.status
+      assert_equal last_response.body, 'Drats! Unable to find a widget file named: nowidget to render.'
+    end
+  end
+
   def with_generated_project
     source_path = File.expand_path('../../templates', __FILE__)
 


### PR DESCRIPTION
This prevents the cryptic ruby raw string being printed if no rendering
template were found.

Closes: #307
