### PR TITLE
Fix vertical size of graph widgets

### DIFF
--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -10,7 +10,7 @@ class Dashing.Graph extends Dashing.Widget
     container = $(@node).parent()
     # Gross hacks. Let's fix this.
     width = (Dashing.widget_base_dimensions[0] * container.data("sizex")) + Dashing.widget_margins[0] * 2 * (container.data("sizex") - 1)
-    height = (Dashing.widget_base_dimensions[1] * container.data("sizey"))
+    height = (Dashing.widget_base_dimensions[1] * container.data("sizey")) + Dashing.widget_margins[1] * 2 * (container.data("sizey") - 1)
     @graph = new Rickshaw.Graph(
       element: @node
       width: width


### PR DESCRIPTION
Corrects graph size when the widget spans multiple rows:
![screen shot 2014-01-28 at 4 04 38 pm](https://f.cloud.github.com/assets/745035/2016455/18da6f78-87db-11e3-8628-ba869a61ac9e.png)
