### PR TITLE
Add month and day to the "Updated At" label on a graph widget.

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -48,9 +48,11 @@ class Dashing.Widget extends Batman.View
   @accessor 'updatedAtMessage', ->
     if updatedAt = @get('updatedAt')
       timestamp = new Date(updatedAt * 1000)
+      month = timestamp.getMonth() + 1
+      day = timestamp.getDate()
       hours = timestamp.getHours()
       minutes = ("0" + timestamp.getMinutes()).slice(-2)
-      "Last updated at #{hours}:#{minutes}"
+      "Last updated at #{hours}:#{minutes} on #{month}/#{day}"
 
   @::on 'ready', ->
     Dashing.Widget.fire 'ready'


### PR DESCRIPTION
We are pulling a large number of metrics from slow/flakey data sources and the "Updated At hour:minute" label on graphs is not sufficient for us to know that something has gone wrong. We may only get a few updates a day and so when something goes wrong it can be days before we notice (based only on the time stamp).  By making the label "Updated At hour:minute on month/day" we notice data retrieval issues much more quickly. 

Thought this might be useful for others...
