### PR TITLE
.icon-background should not block click

### DIFF
--- a/templates/project/assets/stylesheets/application.scss
+++ b/templates/project/assets/stylesheets/application.scss
@@ -117,6 +117,7 @@ h3 {
 }
 
 .icon-background {
+  pointer-events: none;
   width: 100%!important;
   height: 100%;
   position: absolute;


### PR DESCRIPTION
This fix the case that `.icon-background` will block click event.

For example: http://dashingdemo.herokuapp.com/sampletv

If you're trying to bind a `onclick` event to `div.twitter_mentions`, the click event will be blocked by the background icon.
