### PR TITLE
Remove dependencies on Thin, so Dashing can run on JRuby.

### DIFF
--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', '~> 2.0.2')
   s.add_dependency('sinatra', '~> 1.4.4')
   s.add_dependency('sinatra-contrib', '~> 1.4.2')
-  s.add_dependency('thin', '~> 1.6.1')
+  s.add_dependency('puma')
   s.add_dependency('rufus-scheduler', '~> 2.0.24')
   s.add_dependency('thor', '~> 0.18.1')
   s.add_dependency('sprockets', '~> 2.10.1')

--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name        = 'dashing'
+  s.name        = 'dashing-jruby'
   s.version     = '1.3.4'
   s.date        = '2014-05-30'
   s.executables = %w(dashing)

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -6,7 +6,6 @@ require 'coffee-script'
 require 'sass'
 require 'json'
 require 'yaml'
-require 'thin'
 
 SCHEDULER = Rufus::Scheduler.new
 
@@ -118,16 +117,6 @@ get '/views/:widget?.html' do
     file = File.join(settings.root, "widgets", params[:widget], "#{params[:widget]}.#{suffix}")
     return engines.first.new(file).render if File.exist? file
   end
-end
-
-Thin::Server.class_eval do
-  def stop_with_connection_closing
-    Sinatra::Application.settings.connections.dup.each(&:close)
-    stop_without_connection_closing
-  end
-
-  alias_method :stop_without_connection_closing, :stop
-  alias_method :stop, :stop_with_connection_closing
 end
 
 def send_event(id, body, target=nil)

--- a/lib/dashing/cli.rb
+++ b/lib/dashing/cli.rb
@@ -59,14 +59,8 @@ module Dashing
     def start(*args)
       port_option = args.include?('-p') ? '' : ' -p 3030'
       args = args.join(' ')
-      command = "bundle exec thin -R config.ru start#{port_option} #{args}"
+      command = "bundle exec puma #{port_option} #{args} config.ru"
       command.prepend "export JOB_PATH=#{options[:job_path]}; " if options[:job_path]
-      run_command(command)
-    end
-
-    desc "stop", "Stops the thin server"
-    def stop
-      command = "bundle exec thin stop"
       run_command(command)
     end
 


### PR DESCRIPTION
Here's a quick pass to remove the dependency on Thin (and EventMachine) in favor of Puma. This allows dashing to work on JRuby, and Puma is a great server.

I was confused about the connection-closing block that used Thin-specific APIs. We can discuss what that code is doing and how to do it under Puma.
