### PR TITLE
Upgrade rufus-scheduler version

### DIFF
--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sinatra', '~> 1.4.4')
   s.add_dependency('sinatra-contrib', '~> 1.4.2')
   s.add_dependency('thin', '~> 1.6.1')
-  s.add_dependency('rufus-scheduler', '~> 2.0.24')
+  s.add_dependency('rufus-scheduler', '~> 3.0.8')
   s.add_dependency('thor', '~> 0.18.1')
   s.add_dependency('sprockets', '~> 2.10.1')
   s.add_dependency('rack', '~> 1.5.2')


### PR DESCRIPTION
`rufus-scheduler` has a very useful new `overlap` option. In version `2.0` this feature is missing, so can dashing please upgrade to `3.0`?