### PR TITLE
Websockets support

### DIFF
--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', '~> 2.0.2')
   s.add_dependency('sinatra', '~> 1.4.4')
   s.add_dependency('sinatra-contrib', '~> 1.4.2')
+  s.add_dependency('sinatra-websocket','~> 0.3', '>= 0.3.1')
   s.add_dependency('thin', '~> 1.6.1')
   s.add_dependency('rufus-scheduler', '~> 2.0.24')
   s.add_dependency('thor', '~> 0.18.1')

--- a/javascripts/configuration.js.erb
+++ b/javascripts/configuration.js.erb
@@ -1,5 +1,5 @@
 var Configuration={
-	EventEngine: '<%= Sinatra::Application.settings.eventsengine %>',
+	EventEngine: '<%= Sinatra::Application.settings.eventsengine.type %>',
 	SSEUrl: '/events',
 	WSUrl: '/websocket/connection',
 };

--- a/javascripts/configuration.js.erb
+++ b/javascripts/configuration.js.erb
@@ -1,0 +1,3 @@
+var Configuration={
+	EventEngine: '<%= Sinatra::Application.settings.eventsengine %>',
+};

--- a/javascripts/configuration.js.erb
+++ b/javascripts/configuration.js.erb
@@ -1,3 +1,5 @@
 var Configuration={
 	EventEngine: '<%= Sinatra::Application.settings.eventsengine %>',
+	SSEUrl: '/events',
+	WSUrl: '/websocket/connection',
 };

--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -2,6 +2,7 @@
 #= require es5-shim
 #= require batman
 #= require batman.jquery
+#= require configuration
 
 
 Batman.Filters.prettyNumber = (num) ->
@@ -122,4 +123,5 @@ source.addEventListener 'dashboards', (e) ->
     Dashing.fire data.event, data
 
 $(document).ready ->
+  Dashing.source=source
   Dashing.run()

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -1,6 +1,7 @@
 require 'dashing/cli'
 require 'dashing/downloader'
 require 'dashing/app'
+require 'dashing/serversentevents'
 require 'dashing/websockets'
 
 module Dashing

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -1,6 +1,7 @@
 require 'dashing/cli'
 require 'dashing/downloader'
 require 'dashing/app'
+require 'dashing/websockets'
 
 module Dashing
 end

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -40,7 +40,7 @@ set :public_folder, File.join(settings.root, 'public')
 set :views, File.join(settings.root, 'dashboards')
 set :default_dashboard, nil
 set :auth_token, nil
-set :eventsengine, nil
+set :eventsengine, EventsEngine.create(EventsEngineTypes::SSE)
 
 
 if File.exists?(settings.history_file)
@@ -132,8 +132,6 @@ Thin::Server.class_eval do
 end
 
 def send_event(id, body, target=nil)
-  body[:id] = id
-  body[:updatedAt] ||= Time.now.to_i
   Sinatra::Application.settings.eventsengine.send_event(id,body,target)
 end
 

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -25,6 +25,9 @@ helpers do
   end
 end
 
+
+
+
 set :root, Dir.pwd
 set :sprockets,     Sprockets::Environment.new(settings.root)
 set :assets_prefix, '/assets'
@@ -34,12 +37,15 @@ set :public_folder, File.join(settings.root, 'public')
 set :views, File.join(settings.root, 'dashboards')
 set :default_dashboard, nil
 set :auth_token, nil
+set :eventsengine, "SSE"
+
 
 if File.exists?(settings.history_file)
   set history: YAML.load_file(settings.history_file)
 else
   set history: {}
 end
+
 
 %w(javascripts stylesheets fonts images).each do |path|
   settings.sprockets.append_path("assets/#{path}")
@@ -171,6 +177,9 @@ end
 
 settings_file = File.join(settings.root, 'config/settings.rb')
 require settings_file if File.exists?(settings_file)
+
+
+
 
 {}.to_json # Forces your json codec to initialize (in the event that it is lazily loaded). Does this before job threads start.
 job_path = ENV["JOB_PATH"] || 'jobs'

--- a/lib/dashing/constants.rb
+++ b/lib/dashing/constants.rb
@@ -1,4 +1,5 @@
 module EventsEngineTypes
 	SSE="SSE"
-	WS="WS"
+	WS="WSBI"
+	WSEXT="WS"
 end

--- a/lib/dashing/constants.rb
+++ b/lib/dashing/constants.rb
@@ -1,0 +1,4 @@
+class EventsEngines
+	SSE="SSE"
+	WS="WS"
+end

--- a/lib/dashing/constants.rb
+++ b/lib/dashing/constants.rb
@@ -1,4 +1,4 @@
-class EventsEngineTypes
+module EventsEngineTypes
 	SSE="SSE"
 	WS="WS"
 end

--- a/lib/dashing/constants.rb
+++ b/lib/dashing/constants.rb
@@ -1,4 +1,4 @@
-class EventsEngines
+class EventsEngineTypes
 	SSE="SSE"
 	WS="WS"
 end

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -1,0 +1,45 @@
+require 'sinatra'
+
+get '/events', provides: 'text/event-stream' do
+  protected!
+  response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
+  stream :keep_open do |out|
+  	engine.openConnection(out)
+  end
+end
+
+class ServerSentEvents
+	def initialize
+		@connections=[]
+		@history_json=[]
+	def openConnection(out)
+		@connections << out
+			latest_events=@history_json.inject("") do |str,(id,body)| 
+				str << format_event(body.to_json)
+			end
+    	out << latest_events
+    	out.callback { @connections.delete(out) }
+	end	
+	def format_event(body, name=nil)
+	  str = ""
+	  str << "event: #{name}\n" if name
+	  str << "data: #{body}\n\n"
+	end
+	def store_event(body,target=nil)
+		return body if target=='dashboards'
+	  id=body[:id]
+	  @history_json[id].merge!(body) unless @history_json[id].nil?
+	  @history_json[id]=body if @history_json[id].nil?
+	  body=@history_json[id]
+	end
+	def send_event(id, body, target=nil)
+	  body[:id] = id
+	  body[:updatedAt] ||= Time.now.to_i
+	  body=store_event(body,target)
+	  send(body,target)
+	end
+	def send(body,target=nil)
+		event = format_event(body.to_json, target)
+		@connections.each { |out| out << event }
+	end
+end 

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -1,17 +1,37 @@
 require 'sinatra'
+require 'dashing/constants'
 
 get '/events', provides: 'text/event-stream' do
   protected!
   response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
   stream :keep_open do |out|
-  	engine.openConnection(out)
+  	settings.eventsengine.openConnection(out)
   end
 end
 
-class ServerSentEvents
-	def initialize
+class EventsEngine
+  @@subclasses = { }
+  attr_reader :type
+  def self.create type
+    c = @@subclasses[type]
+    if c
+      c.new(type)
+    else
+      raise "Bad events engine type: #{type}"
+    end
+  end
+  def self.register_engine name
+    @@subclasses[name] = self
+  end
+end
+
+class ServerSentEvents < EventsEngine
+	register_engine EventsEngineTypes::SSE
+	def initialize(type)
+		@type=type
 		@connections=[]
-		@history_json=[]
+		@history_json={}
+	end
 	def openConnection(out)
 		@connections << out
 			latest_events=@history_json.inject("") do |str,(id,body)| 
@@ -30,6 +50,7 @@ class ServerSentEvents
 	  id=body[:id]
 	  @history_json[id].merge!(body) unless @history_json[id].nil?
 	  @history_json[id]=body if @history_json[id].nil?
+	  print "#{self}\n"
 	  body=@history_json[id]
 	end
 	def send_event(id, body, target=nil)
@@ -41,5 +62,11 @@ class ServerSentEvents
 	def send(body,target=nil)
 		event = format_event(body.to_json, target)
 		@connections.each { |out| out << event }
+	end
+	def stop
+		@connections.dup.each(&:close)
+	end
+	def onclose(conn)
+		@connections.delete(conn)
 	end
 end 

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -38,7 +38,7 @@ class ServerSentEvents < EventsEngine
 				str << format_event(body.to_json)
 			end
     	out << latest_events
-    	out.callback { @connections.delete(out) }
+    	out.callback { onclose(conn) }
 	end	
 	def format_event(body, name=nil)
 	  str = ""

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -23,6 +23,12 @@ class EventsEngine
   def self.register_engine name
     @@subclasses[name] = self
   end
+  def send_event(body,target=nil)
+  	raise "EventsEngine is abstract. send_event is not implemented."
+  end
+  def stop
+  	raise "EventsEngine is abstract. stop is not implemented."
+  end
 end
 
 class ServerSentEvents < EventsEngine

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -44,7 +44,7 @@ class ServerSentEvents < EventsEngine
 				str << format_event(body.to_json)
 			end
     	out << latest_events
-    	out.callback { onclose(conn) }
+    	out.callback { onclose(out) }
 	end	
 	def format_event(body, name=nil)
 	  str = ""

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -56,12 +56,11 @@ class ServerSentEvents < EventsEngine
 	  id=body[:id]
 	  @history_json[id].merge!(body) unless @history_json[id].nil?
 	  @history_json[id]=body if @history_json[id].nil?
-	  print "#{self}\n"
 	  body=@history_json[id]
 	end
 	def send_event(id, body, target=nil)
 	  body[:id] = id
-	  body[:updatedAt] ||= Time.now.to_i
+	  body[:updatedAt] ||= (Time.now.to_f * 1000).ceil
 	  body=store_event(body,target)
 	  send(body,target)
 	end

--- a/lib/dashing/serversentevents.rb
+++ b/lib/dashing/serversentevents.rb
@@ -69,7 +69,8 @@ class ServerSentEvents < EventsEngine
 		@connections.each { |out| out << event }
 	end
 	def stop
-		@connections.dup.each(&:close)
+		@connections.dup.each {|conn| conn.close}
+		@connections.clear()
 	end
 	def onclose(conn)
 		@connections.delete(conn)

--- a/lib/dashing/websockets.rb
+++ b/lib/dashing/websockets.rb
@@ -67,11 +67,7 @@ class WebSocketEvents < ServerSentEvents
 		@subscription[body[:id]].each { |out| out.send(format_event(body)) } unless @subscription[body[:id]].nil?
 	end
 	def onclose(socket)
-		if super.nil? then 
-			print "ERRRRRORRR Super is null\n"
-		else
-			super.onclose(socket)
-		end
+		super(socket)
 		@subscription.each {|id,connlist| connlist.delete(socket) }
 	end
 end

--- a/lib/dashing/websockets.rb
+++ b/lib/dashing/websockets.rb
@@ -8,53 +8,60 @@ WS_SUPPORTED_SERVER = ['thin']
 
 get '/websocket/connection' do
 	halt 400,"Accepting only websocket connections" unless request.websocket?
-	halt 400,"Websockets are disabled in server the configuration" unless settings.eventsengine==EventsEngines::WS
+	halt 400,"Websockets are disabled in server the configuration" unless settings.eventsengine.type==EventsEngineTypes::WS
 	halt 500,"Invalid server configuration" unless WS_SUPPORTED_SERVER.include? settings.server
 	request.websocket do |ws|
 		ws.onopen do
-			ws.send('{"type":"ack","data":{"result":"ok"}}')
-			engine.websockets << ws
+			ws.send({type:"ack",data:{result:"ok"}}.to_json)
+			#settings.engine.websockets << ws
 		end
 		ws.onmessage do |msg|
 			begin
 				message=JSON.parse(msg)
-				case message.type
+				case message['type']
 					when 'subscribe'
-						engine.openConnection(ws,message)
-						engine.openConnection()
+						settings.eventsengine.openConnection(ws,message)
 					when 'event'
+						logger.warn("events from a client are not supported")
+					end
 			rescue Exception => e
 				logger.warn(e.message)
 				logger.warn(e.backtrace.inspect)
 			end 
-			print settings.websockets[0].inspect + "\n"
-
-			EM.next_tick { settings.websockets.each{|s| s.send(msg) } }
 		end
 		ws.onclose do
 			warn("websocket closed")
-			settings.websockets.delete(ws)
+			settings.eventsengine.onclose(ws)
 		end
 	end
 end		
 
 class WebSocketEvents < ServerSentEvents
-	def initialize
-		super
+	register_engine EventsEngineTypes::WS
+	def initialize(type)
+		super(type)
 		@subscription={}
 	end
 	def openConnection(out,message)
-		message.data.events.each do |id| 
+		@connections << out
+		message['data']['events'].each do |id| 
 			@subscription[id]=[] if @subscription[id].nil?
 			@subscription[id] << out
 		end
-		lastevents=@history_json.select { |key,val| @subscriptions.include? key }.values.to_json
-		out.send('{"type":"subscribe", "data":{"result":"ok"}}')
-		out.send('{"type":"event","data": [#{lastevents}}]')
+		lastevents=@history_json.select { |key,val| @subscription.key?(key) }.values
+		out.send({type:"subscribe", data:{result:"ok"}}.to_json)
+		out.send({type:"event",data: lastevents}.to_json)
 	end
 	def format_event(body,target=nil)
-		'{"type":"event","data":#{body.to_json}}'
+		evttype= target.nil? ? "event" : target
+		{type:evttype,data: body}.to_json
 	end
 	def send(body,target=nil)
-		@subscription[body[:id]].each { |out| out.send(format_event(body)) }
+		if target=='dashboards'
+			print "#{body}:#{target}\n"
+			print "#{@connections.to_json}\n"
+			@connections.each { |ws| ws.send(format_event(body,target)) }
+		end
+		@subscription[body[:id]].each { |out| out.send(format_event(body)) } unless @subscription[body[:id]].nil?
 	end
+end

--- a/lib/dashing/websockets.rb
+++ b/lib/dashing/websockets.rb
@@ -1,0 +1,60 @@
+require 'sinatra'
+require 'sinatra-websocket'
+require 'dashing/constants'
+require 'dashing/serversentevents'
+
+
+WS_SUPPORTED_SERVER = ['thin']
+
+get '/websocket/connection' do
+	halt 400,"Accepting only websocket connections" unless request.websocket?
+	halt 400,"Websockets are disabled in server the configuration" unless settings.eventsengine==EventsEngines::WS
+	halt 500,"Invalid server configuration" unless WS_SUPPORTED_SERVER.include? settings.server
+	request.websocket do |ws|
+		ws.onopen do
+			ws.send('{"type":"ack","data":{"result":"ok"}}')
+			engine.websockets << ws
+		end
+		ws.onmessage do |msg|
+			begin
+				message=JSON.parse(msg)
+				case message.type
+					when 'subscribe'
+						engine.openConnection(ws,message)
+						engine.openConnection()
+					when 'event'
+			rescue Exception => e
+				logger.warn(e.message)
+				logger.warn(e.backtrace.inspect)
+			end 
+			print settings.websockets[0].inspect + "\n"
+
+			EM.next_tick { settings.websockets.each{|s| s.send(msg) } }
+		end
+		ws.onclose do
+			warn("websocket closed")
+			settings.websockets.delete(ws)
+		end
+	end
+end		
+
+class WebSocketEvents < ServerSentEvents
+	def initialize
+		super
+		@subscription={}
+	end
+	def openConnection(out,message)
+		message.data.events.each do |id| 
+			@subscription[id]=[] if @subscription[id].nil?
+			@subscription[id] << out
+		end
+		lastevents=@history_json.select { |key,val| @subscriptions.include? key }.values.to_json
+		out.send('{"type":"subscribe", "data":{"result":"ok"}}')
+		out.send('{"type":"event","data": [#{lastevents}}]')
+	end
+	def format_event(body,target=nil)
+		'{"type":"event","data":#{body.to_json}}'
+	end
+	def send(body,target=nil)
+		@subscription[body[:id]].each { |out| out.send(format_event(body)) }
+	end

--- a/lib/dashing/websockets.rb
+++ b/lib/dashing/websockets.rb
@@ -42,7 +42,11 @@ class WebSocketEvents < ServerSentEvents
 		super(type)
 		@subscription={}
 	end
-	def openConnection(out,message)
+	def openConnection(out,message=nil)
+		if message.nil? then 
+			out <<  "data: incorrect subscription event"
+			return
+		end
 		@connections << out
 		message['data']['events'].each do |id| 
 			@subscription[id]=[] if @subscription[id].nil?
@@ -63,7 +67,11 @@ class WebSocketEvents < ServerSentEvents
 		@subscription[body[:id]].each { |out| out.send(format_event(body)) } unless @subscription[body[:id]].nil?
 	end
 	def onclose(socket)
-		super.onclose(socket)
+		if super.nil? then 
+			print "ERRRRRORRR Super is null\n"
+		else
+			super.onclose(socket)
+		end
 		@subscription.each {|id,connlist| connlist.delete(socket) }
 	end
 end

--- a/lib/dashing/websockets.rb
+++ b/lib/dashing/websockets.rb
@@ -65,4 +65,5 @@ class WebSocketEvents < ServerSentEvents
 	def onclose(socket)
 		super.onclose(socket)
 		@subscription.each {|id,connlist| connlist.delete(socket) }
+	end
 end

--- a/templates/project/config.ru
+++ b/templates/project/config.ru
@@ -2,7 +2,7 @@ require 'dashing'
 
 configure do
   set :auth_token, 'YOUR_AUTH_TOKEN'
-
+  set :eventsengine, EventsEngine.create(EventsEngineTypes::SSE)
   helpers do
     def protected!
      # Put any authentication code you want in here.
@@ -16,3 +16,8 @@ map Sinatra::Application.assets_prefix do
 end
 
 run Sinatra::Application
+
+{}.to_json # Forces your json codec to initialize (in the event that it is lazily loaded). Does this before job threads start.
+job_path = ENV["JOB_PATH"] || 'jobs'
+require_glob(File.join('lib', '**', '*.rb'))
+require_glob(File.join(job_path, '**', '*.rb'))

--- a/templates/project/config.ru
+++ b/templates/project/config.ru
@@ -1,4 +1,5 @@
 require 'dashing'
+require 'dashing/constants'
 
 configure do
   set :auth_token, 'YOUR_AUTH_TOKEN'

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -4,7 +4,7 @@ require 'haml'
 class AppTest < Dashing::Test
   def setup
     @connection = []
-    app.settings.connections = [@connection]
+    app.settings.eventsengine.instance_variable_set(:@connections,  [@connection])
     app.settings.auth_token = nil
     app.settings.default_dashboard = nil
     app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')

--- a/test/eventsengine_test.rb
+++ b/test/eventsengine_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class EventsEngineAbsractTest < Dashing::Test
+    def setup
+    end
+    def test_exceptions_raised
+        ee = EventsEngine.new
+        assert_raises(RuntimeError) {ee.send_event('a','b')}
+        assert_raises(RuntimeError) {ee.stop}
+    end
+    def test_engine_registrations
+        ee = EventsEngine.new
+        assert_raises(RuntimeError) {EventsEngine.create "not_exist"}
+    end
+end

--- a/test/serversentevents_test.rb
+++ b/test/serversentevents_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'haml'
+
+class ServerSentEventsTest < Dashing::Test
+    def setup
+        @connection=[]
+        
+        app.settings.eventsengine.instance_variable_set(:@connections,  [@connection])
+        app.settings.auth_token = nil
+        app.settings.default_dashboard = nil
+        app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')
+    end
+    def app
+        Sinatra::Application
+    end
+    def eventsengine
+        Sinatra::Application.settings.eventsengine
+    end
+    def test_stop_engine
+        @connection.stubs(:close).returns(true).at_least_once
+        eventsengine.stop()
+        assert_equal 0,eventsengine.instance_variable_get(:@connections).length
+    end    
+end

--- a/test/websockets_test.rb
+++ b/test/websockets_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+require 'json'
+require 'sinatra-websocket/ext/thin/connection'
+
+class WebSocketEventsTest < Dashing::Test
+    def setup
+        @connection=[]
+        app.settings.eventsengine = EventsEngine.create(EventsEngineTypes::WS)
+        app.settings.auth_token = nil
+        app.settings.default_dashboard = nil
+        app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')
+        app.settings.server='thin'
+    end
+    def app
+        Sinatra::Application
+    end
+    def eventsengine
+        Sinatra::Application.settings.eventsengine
+    end
+    def test_no_subscriptions
+        connection=[]
+        connection.expects(:send).with(:body) do |body|
+            objs = JSON.parse(body)
+            assert objs['data']['result']=='ok' if objs['type']=='subscribe'
+            assert objs['data'].length==0 if objs['type']=='event'
+            connection << body
+        end.at_least_once
+        eventsengine.openConnection(connection)
+        assert_equal 1,connection.length
+        assert_raises(NoMethodError) {eventsengine.openConnection(connection,{})}
+        eventsengine.openConnection(connection,{'data'=>{'events'=>[]}})
+        eventsengine.send_event('id',{data:'data'})
+    end
+    def test_subscriptions
+        connection=[]
+        connection.expects(:send).with(:body) do |body|
+            objs = JSON.parse(body)
+            assert objs['data'].length>0 if objs['type']=='event'
+            connection << body
+        end.at_least_once
+        eventsengine.send_event('id',{data:'data'})
+        eventsengine.openConnection(connection,{'data'=>{'events'=>['id']}})
+        assert_equal 2,connection.length
+        eventsengine.send_event('id2',{data:'data'})
+        assert_equal 2,connection.length
+    end
+    def test_connection
+        get "/websocket/connection",{},'HTTP_CONNECTION'=>'a,upgrade','HTTP_UPGRADE'=>'websocket'
+    end
+    def test_init_connection
+        request = mock()
+        connection=[]
+        connection.expects(:send).with(:body) { |body| connection <<body }.at_least_once       
+        connection.expects(:onopen).yields().at_least_once
+        connection.stubs(:onclose).yields()
+        connection.expects(:onmessage).yields({type:'subsribe','data'=>{'events'=>['id']}}.to_json)
+        request.expects(:websocket).yields(connection).at_least_once
+        logger=mock('logger')
+        logger.expects(:warn).with("websocket closed")
+        WebSocketEvents.init_websocket_connection(request,logger)
+    end
+    def test_init_invalid_connection
+        request = mock()
+        connection=[]
+        connection.expects(:send).with(:body) { |body| connection <<body }.times(2)       
+        connection.expects(:onopen).yields().times(2)
+        connection.stubs(:onclose).yields()
+        connection.expects(:onmessage).yields({type:'subsribe','data'=>{'events'=>['id']}})
+        request.expects(:websocket).yields(connection).at_least_once
+        logger=mock('logger')
+        logger.expects(:warn).times(5)
+        WebSocketEvents.init_websocket_connection(request,logger)
+        connection.expects(:onmessage).yields({type:'event','data'=>{'events'=>['id']}}.to_json)
+        WebSocketEvents.init_websocket_connection(request,logger)
+    end
+end

--- a/websockets.md
+++ b/websockets.md
@@ -16,3 +16,45 @@ The above selects websocket engine.
 Currently supported engines are:
 * ServerSideEvents - _EventsEngineTypes::SSE_
 * WebSockets - _EventsEngineTypes::WS_
+
+## Add your own engine
+To add an engine, you need to provide a route for accepting request and subclass EventsEngine class. Optionally you could add a constant to the EventsEngineType module to improve code readability. You also need to add engine on the client side. 
+
+__1. add constant__
+```ruby
+module EventsEngineTypes
+	WEBSOCKET2="WS2" #new web socket implementation
+end
+```
+
+__2. route__: 
+```ruby
+get '/events', provides: 'text/event-stream' do
+  protected!
+  response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
+  stream :keep_open do |out|
+  	settings.eventsengine.openConnection(out)
+  end
+end
+```
+
+__3. subclass EventsEngine__:
+You need to subclass EventsEngine class, register your new engine and implement _send_event_ and _stop_ methods
+```ruby
+class NewCoolWebSockets < EventsEngine
+	register_engine EventsEngineTypes::WEBSOCKET2
+	def stop
+	end
+	def send_event(body, target=nil)
+	end
+end
+```
+
+__4. add engine on the client side__
+```coffee
+  $(document).ready -> 
+  	if Configuration.EventEngine=="WS2"
+  		Dashing.source= -> 
+  			.... create your own engine...
+```
+> Please note that client side uses the value of the EventsEngineType's constant, not its name

--- a/websockets.md
+++ b/websockets.md
@@ -1,3 +1,13 @@
+# Compatibility issue
+The calling job files code was moved from the gem level to the project level (__config.ru__). To make you existent jobs and lib files to be called from application one need to add the following lines of code: 
+```ruby
+{}.to_json # Forces your json codec to initialize (in the event that it is lazily loaded). Does this before job threads start.
+job_path = ENV["JOB_PATH"] || 'jobs'
+require_glob(File.join('lib', '**', '*.rb'))
+require_glob(File.join(job_path, '**', '*.rb'))
+```
+to the end of the project's __config.ru__ file 
+
 # Events Engines
 Dashing provides two engines for processing events to and from clients. __ServerSentEvents__ and __WebSockets__. The __ServerSentEvents__ engine provides one way comunication from the dashing server to a client. __WebSockets__ engine provides two way communication and supports subscriptions to reduce traffic between the server and the client. A dashboard automatically subscribes to receive message only for widgets it contains.
 

--- a/websockets.md
+++ b/websockets.md
@@ -1,0 +1,18 @@
+# Events Engines
+Dashing provides two engines for processing events to and from clients. __ServerSentEvents__ and __WebSockets__. The __ServerSentEvents__ engine provides one way comunication from the dashing server to a client. __WebSockets__ engine provides two way communication and supports subscriptions to reduce traffic between the server and the client. A dashboard automatically subscribes to receive message only for widgets it contains.
+
+## Engine Selection
+Dashing is using _eventsengine_ setting as engine instance reference. One can select the engine type during the configuration of the application: 
+
+__config.ru:__
+```ruby
+configure do
+  set :auth_token, 'YOUR_AUTH_TOKEN'
+  set :eventsengine, EventsEngine.create(EventsEngineTypes::WS)
+end
+```
+The above selects websocket engine.
+
+Currently supported engines are:
+* ServerSideEvents - _EventsEngineTypes::SSE_
+* WebSockets - _EventsEngineTypes::WS_


### PR DESCRIPTION
# Compatibility issue
The calling job files code was moved from the gem level to the project level (__config.ru__). To make you existent jobs and lib files to be called from application one need to add the following lines of code: 
```ruby
{}.to_json # Forces your json codec to initialize (in the event that it is lazily loaded). Does this before job threads start.
job_path = ENV["JOB_PATH"] || 'jobs'
require_glob(File.join('lib', '**', '*.rb'))
require_glob(File.join(job_path, '**', '*.rb'))
```
to the end of the project's __config.ru__ file 

# Events Engines
Dashing provides two engines for processing events to and from clients. __ServerSentEvents__ and __WebSockets__. The __ServerSentEvents__ engine provides one way comunication from the dashing server to a client. __WebSockets__ engine provides two way communication and supports subscriptions to reduce traffic between the server and the client. A dashboard automatically subscribes to receive message only for widgets it contains.

## Engine Selection
Dashing is using _eventsengine_ setting as engine instance reference. One can select the engine type during the configuration of the application: 

__config.ru:__
```ruby
configure do
  set :auth_token, 'YOUR_AUTH_TOKEN'
  set :eventsengine, EventsEngine.create(EventsEngineTypes::WS)
end
```
The above selects websocket engine.

Currently supported engines are:
* ServerSideEvents - _EventsEngineTypes::SSE_
* WebSockets - _EventsEngineTypes::WS_

## Add your own engine
To add an engine, you need to provide a route for accepting request and subclass EventsEngine class. Optionally you could add a constant to the EventsEngineType module to improve code readability. You also need to add engine on the client side. 

__1. add constant__
```ruby
module EventsEngineTypes
	WEBSOCKET2="WS2" #new web socket implementation
end
```

__2. route__: 
```ruby
get '/events', provides: 'text/event-stream' do
  protected!
  response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
  stream :keep_open do |out|
  	settings.eventsengine.openConnection(out)
  end
end
```

__3. subclass EventsEngine__:
You need to subclass EventsEngine class, register your new engine and implement _send_event_ and _stop_ methods
```ruby
class NewCoolWebSockets < EventsEngine
	register_engine EventsEngineTypes::WEBSOCKET2
	def stop
	end
	def send_event(body, target=nil)
	end
end
```

__4. add engine on the client side__
```coffee
  $(document).ready -> 
  	if Configuration.EventEngine=="WS2"
  		Dashing.source= -> 
  			.... create your own engine...
```
> Please note that client side uses the value of the EventsEngineType's constant, not its name
