### PR TITLE
Trigger onData on widget initialization

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -40,7 +40,12 @@ class Dashing.Widget extends Batman.View
     @mixin($(@node).data())
     Dashing.widgets[@id] ||= []
     Dashing.widgets[@id].push(@)
-    @mixin(Dashing.lastEvents[@id]) # in case the events from the server came before the widget was rendered
+
+    # In case the events from the server came before the widget was rendered
+    lastData = Dashing.lastEvents[@id]
+    if lastData
+      @mixin(lastData)
+      @onData(lastData)
 
     type = Batman.Filters.dashize(@view)
     $(@node).addClass("widget widget-#{type} #{@id}")

--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -114,8 +114,8 @@ source.addEventListener 'message', (e) ->
   if lastEvents[data.id]?.updatedAt != data.updatedAt
     if Dashing.debugMode
       console.log("Received data for #{data.id}", data)
+    lastEvents[data.id] = data
     if widgets[data.id]?.length > 0
-      lastEvents[data.id] = data
       for widget in widgets[data.id]
         widget.receiveData(data)
 

--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -41,12 +41,6 @@ class Dashing.Widget extends Batman.View
     Dashing.widgets[@id] ||= []
     Dashing.widgets[@id].push(@)
 
-    # In case the events from the server came before the widget was rendered
-    lastData = Dashing.lastEvents[@id]
-    if lastData
-      @mixin(lastData)
-      @onData(lastData)
-
     type = Batman.Filters.dashize(@view)
     $(@node).addClass("widget widget-#{type} #{@id}")
 
@@ -59,6 +53,12 @@ class Dashing.Widget extends Batman.View
 
   @::on 'ready', ->
     Dashing.Widget.fire 'ready'
+
+    # In case the events from the server came before the widget was rendered
+    lastData = Dashing.lastEvents[@id]
+    if lastData
+      @mixin(lastData)
+      @onData(lastData)
 
   receiveData: (data) =>
     @mixin(data)


### PR DESCRIPTION
Currently, when a widget is initialized the last event associated is mixed in, but the `onData` hook is not being executed, leading to problems with more complex widgets which rely on data processing. This pull request solves that problem. Additionally, it ensures that last events are stored even before widgets are initialized in order to avoid race conditions.