### PR TITLE
Make sure a 404 is returned for non existing dashboard

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -50,7 +50,7 @@ end
 end
 
 not_found do
-  send_file File.join(settings.public_folder, '404.html')
+  send_file File.join(settings.public_folder, '404.html'), status: 404
 end
 
 at_exit do

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -129,6 +129,13 @@ class AppTest < Dashing::Test
     end
   end
 
+  def test_get_nonexistent_dashboard_sends_file_with_404_status
+    with_generated_project do
+      app.any_instance.expects(:send_file).with(anything, has_entry(:status, 404))
+      get '/nodashboard'
+    end
+  end
+
   def test_get_widget
     with_generated_project do
       get '/views/meter.html'


### PR DESCRIPTION
Currently, when a user tries to access an non existing dashboard, she gets a 200 OK response like seen in the screenshot below. This pull request fixes this by passing the `status` option to `send_file`.

![no-404](https://cloud.githubusercontent.com/assets/35639/7339672/9d1af828-ec77-11e4-8658-b1a8a4ce4f95.png)