### PR TITLE
Remove redundant test

### DIFF
--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -152,6 +152,7 @@ class AppTest < Dashing::Test
       cli.stubs(:source_paths).returns([source_path])
       silent { cli.new 'new_project' }
 
+      app.settings.public_folder = File.join(dir, 'new_project/public')
       app.settings.views = File.join(dir, 'new_project/dashboards')
       app.settings.root = File.join(dir, 'new_project')
       yield app.settings.root

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -129,13 +129,6 @@ class AppTest < Dashing::Test
     end
   end
 
-  def test_get_nonexistent_dashboard_sends_file_with_404_status
-    with_generated_project do
-      app.any_instance.expects(:send_file).with(anything, has_entry(:status, 404))
-      get '/nodashboard'
-    end
-  end
-
   def test_get_widget
     with_generated_project do
       get '/views/meter.html'


### PR DESCRIPTION
The other day I opened pull request #558 that got merged into master. I wrote a test to exercise my change but it felt a little unnecessary because the [existing test][1] should have caught the problem. However it didn't, so I wrote my own test.

But now I've figured out why the existing test didn't fail: because the generated test project's public folder wasn't set correctly. It pointed to the non existent public folder in the current working directory (the dashing project directory).

I propose setting public folder correctly and remove my redundant test with this pull request.

[1]: https://github.com/Shopify/dashing/blob/66cd2039a3397387cd5399d65a415ceb53a12a32/test/app_test.rb#L125