### PR TITLE
FIX for application restart when srv not reachable

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -110,6 +110,7 @@ source.addEventListener 'error', (e)->
 
 source.addEventListener 'message', (e) ->
   clearTimeout(errorTimerId)
+  errorTimerId = null
   data = JSON.parse(e.data)
   if lastEvents[data.id]?.updatedAt != data.updatedAt
     if Dashing.debugMode

--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -96,15 +96,20 @@ source = new EventSource('events')
 source.addEventListener 'open', (e) ->
   console.log("Connection opened", e)
 
+errorTimerId = null
+
 source.addEventListener 'error', (e)->
   console.log("Connection error", e)
-  if (e.currentTarget.readyState == EventSource.CLOSED)
+  UNINITIALIZED = 0
+  if (e.currentTarget.readyState == UNINITIALIZED ||
+        e.currentTarget.readyState == EventSource.CLOSED)
     console.log("Connection closed")
-    setTimeout (->
+    errorTimerId = setTimeout (->
       window.location.reload()
     ), 5*60*1000
 
 source.addEventListener 'message', (e) ->
+  clearTimeout(errorTimerId)
   data = JSON.parse(e.data)
   if lastEvents[data.id]?.updatedAt != data.updatedAt
     if Dashing.debugMode
@@ -123,3 +128,4 @@ source.addEventListener 'dashboards', (e) ->
 
 $(document).ready ->
   Dashing.run()
+


### PR DESCRIPTION
```
Tested on Mac OS X Yosemite, Chrome Version 43.0.2357.132 (64-bit)

Steps to reproduce:

1. Run service by `dashing start`
2. View a dashboard
3. kill the service by CTRL + D
4. wait for five minutes.

expectation:
page should reload

what happens:
e.currentTarget.readyState is  0 (not initialized)
chrome's EventSource API tries to reconnect to a non-existent server over and over again.
The page never refreshes.

We clear errorTimerId immediately after we get a message event, so that there won't be redundant restarts.

On an edge case, the service might reconnect and won't get any messages for a while which might trigger the timer with errorTimerId; and that will cause only one extra refresh only.
```
