### PR TITLE
:bug: Fix data-*color view bindings

### DIFF
--- a/templates/project/widgets/meter/meter.coffee
+++ b/templates/project/widgets/meter/meter.coffee
@@ -9,6 +9,6 @@ class Dashing.Meter extends Dashing.Widget
 
   ready: ->
     meter = $(@node).find(".meter")
-    meter.attr("data-bgcolor", meter.css("background-color"))
-    meter.attr("data-fgcolor", meter.css("color"))
+    meter.css("background-color", meter.data("bgcolor"))
+    meter.css("color", meter.data("fgcolor"))
     meter.knob()

--- a/templates/project/widgets/meter/meter.coffee
+++ b/templates/project/widgets/meter/meter.coffee
@@ -9,6 +9,6 @@ class Dashing.Meter extends Dashing.Widget
 
   ready: ->
     meter = $(@node).find(".meter")
-    meter.css("background-color", meter.data("bgcolor"))
-    meter.css("color", meter.data("fgcolor"))
+    meter.css("background-color", meter.data("bgcolor")) if meter.data("bgcolor")
+    meter.css("color", meter.data("fgcolor")) if meter.data("fgcolor")
     meter.knob()


### PR DESCRIPTION
They were setting the data attributes to the CSS properties instead of the other way around.

Fixes #613.