### PR TITLE
Fix: calling set with same value twice breaks update

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -83,7 +83,7 @@ Dashing.AnimatedValue =
         @[timer] =
           setInterval =>
             num = if up then Math.ceil(num+num_interval) else Math.floor(num-num_interval)
-            if (up && num > to) || (!up && num < to)
+            if (up && num >= to) || (!up && num <= to)
               num = to
               clearInterval(@[timer])
               @[timer] = null


### PR DESCRIPTION
When you push a value that is equal to the prior value, the call to `clearInterval()` never happens so further updates are continually overwritten by the interval that was never cleared. This allows for values that are equal to pass through and clear the previous interval.
