### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.author      = "Daniel Beauchamp"
   s.email       = 'daniel.beauchamp@shopify.com'
   s.homepage    = 'http://shopify.github.com/dashing'
+  s.license     = "MIT"
 
   s.files = Dir['README.md', 'javascripts/**/*', 'templates/**/*','templates/**/.[a-z]*', 'lib/**/*']
 


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.
