### PR TITLE
Fix for issue #672

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -83,7 +83,7 @@ Dashing.AnimatedValue =
         @[timer] =
           setInterval =>
             num = if up then Math.ceil(num+num_interval) else Math.floor(num-num_interval)
-            if (up && num > to) || (!up && num < to)
+            if (up && num >= to) || (!up && num <= to)
               num = to
               clearInterval(@[timer])
               @[timer] = null


### PR DESCRIPTION
Any widget that uses Dashing.AnimatedValue will lock up if sent current and last values which are the same but different object types ie. current = '5' and last = 5.

Problem is due to CoffeeScript translating == comparison on line 78 into a === comparison, which fails when given different object types.  As the num and to values are the same, the increment is zero.  The timer termination test only checked if the num value had passed the to value, which it would never do if increment is zero. The fix adds a test if the num and to values are equal so that the timer runs once but then terminates.
