### PR TITLE
Event handlers and query param auth_token

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -94,7 +94,7 @@ post '/dashboards/:id' do
   request.body.rewind
   body = JSON.parse(request.body.read)
   body['dashboard'] ||= params['id']
-  if authenticated?(body.delete("auth_token"))
+  if authenticated?(params[:auth_token] || body.delete("auth_token"))
     send_event(params['id'], body, 'dashboards')
     204 # response without entity body
   else
@@ -106,7 +106,7 @@ end
 post '/widgets/:id' do
   request.body.rewind
   body = JSON.parse(request.body.read)
-  if authenticated?(body.delete("auth_token"))
+  if authenticated?(params[:auth_token] || body.delete("auth_token"))
     send_event(params['id'], body)
     204 # response without entity body
   else

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -39,6 +39,7 @@ set :public_folder, File.join(settings.root, 'public')
 set :views, File.join(settings.root, 'dashboards')
 set :default_dashboard, nil
 set :auth_token, nil
+set :event_handlers, {}
 
 if File.exists?(settings.history_file)
   set history: YAML.load_file(settings.history_file)
@@ -115,6 +116,18 @@ post '/widgets/:id' do
   end
 end
 
+post '/trigger/:id' do
+  request.body.rewind
+  body = JSON.parse(request.body.read)
+  if authenticated?(params[:auth_token] || body.delete("auth_token"))
+    call_event_handlers(params['id'], body)
+    204 # response without entity body
+  else
+    status 401
+    "Invalid API key\n"
+  end
+end
+
 get '/views/:widget?.html' do
   protected!
   tilt_html_engines.each do |suffix, engines|
@@ -136,9 +149,25 @@ end
 def send_event(id, body, target=nil)
   body[:id] = id
   body[:updatedAt] ||= Time.now.to_i
+  call_event_handlers(id, body)
   event = format_event(body.to_json, target)
   Sinatra::Application.settings.history[id] = event unless target == 'dashboards'
   Sinatra::Application.settings.connections.each { |out| out << event }
+end
+
+def call_event_handlers(id, body)
+  if Sinatra::Application.event_handlers[id]
+    Sinatra::Application.event_handlers[id].each do |handler|
+      handler.call(body)
+    end
+  end
+end
+
+def handle_event(id, &block)
+  unless Sinatra::Application.event_handlers[id]
+    Sinatra::Application.event_handlers[id] = []
+  end
+  Sinatra::Application.event_handlers[id] << block
 end
 
 def format_event(body, name=nil)


### PR DESCRIPTION
This pull request adds the following two features to dashing:

* Allows the auth_token to be a query parameter in addition to being included in the POSTed widget json. This allows for wiring into hooks from 3rd party webhooks (like shopify!) where you cannot control the payload, just the URL.

* Creates a new concept of an 'event handler' whereby backend ruby code can be invoked when widget JSON is received from a web request. It also creates a new http path called /trigger/:id to invoke the handler, but not have the payload rebroadcast to all the dashing web frontends. A simple use case allowing dashing to receive a webhook from some 3rd party, extract/normalize some data from it, and then formulate a send_event() that is broadcast to all the connected browser frontends. 

A new widget I created allows dashing to play a sound via the html5 audio API when some backend webhook happens (such as a new e-commerce purchase from a shopify store ;)).
