### PR TITLE
Update travis config to current ruby versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.2
-  - 2.0.0
-  - 1.9.3
+  - 2.3.0
+  - 2.2.4
+  - 2.1.8
 
 script: "rake test"


### PR DESCRIPTION
This has the nice side effect of fixing the failing travis builds. :-)
The build failures seen with older ruby versions (for example on 1.9.3) seem to be due to the following bundler bug:
https://github.com/bundler/bundler/issues/3558
fixes #682 