### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,16 @@ Dashing is a Sinatra based framework that lets you build beautiful dashboards. I
 
 Note: Dashing is no longer being actively maintained. Read about it [here](https://github.com/Shopify/dashing/issues/711).
 
+
+# Nitrous Quickstart
+You can quickly create a free development environment for this Dashing project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Dashing via `Run > Start Dashing` and access your site via `Preview > 3030`.
+
+
 # License
 Distributed under the [MIT license](MIT-LICENSE)

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Dashing project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start dashing via "Run > Start Dashing".
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3030".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,11 @@
+{
+  "template": "ruby",
+  "ports": [3030],
+  "name": "Dashing",
+  "description": "Dashing is a Sinatra based framework that lets you build beautiful dashboards. It looks especially great on TVs.",
+  "no_clone": true,
+  "scripts": {
+    "post-create": "cd /home/nitrous/code && gem install dashing && dashing new sweet_dashboard_project && cd sweet_dashboard_project && bundle",
+    "Start Dashing": "cd ~/code/sweet_dashboard_project && dashing start"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically install Dashing and configure any required packages.
